### PR TITLE
Custom errors for ERC tokens

### DIFF
--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -239,7 +239,7 @@ Considering this, the error names are designed following a basic grammatical str
 
 The main actions that can be performed within a token are:
 
-- **Transfer**: An operation in which a _sender_ moves any form of _balance_ to a _receiver_.
+- **Transfer**: An operation in which a _sender_ moves to a _receiver_ any number of tokens (fungible _balance_ and/or non-fungible _token ids_).
 - **Approval**: An operation in which an _approver_ grants any form of _approval_ to an _operator_.
 
 Whose subjects outlined are expected to be exhaustive to represent _what_ can go wrong in a transaction, which can be shown as an error by adding a [failure prefix](#error-prefixes).

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -297,7 +297,7 @@ The selection of arguments depends on the subject involved, and it SHOULD follow
 2. _What_ failed (eg. `uint256 allowance`)
 3. _Why_ it failed, expressed in additional arguments (eg. `uint256 needed`)
 
-Consider arguments can overlap (eg. _Who_ is also _What_), so not all of the arguments will be present but the order SHOULD NOT be broken.
+A particular argument may fall in overlapping categories (eg. _Who_ may also be _What_), so not all of these will be present but the order SHOULD NOT be broken.
 
 Note: Some tokens may need a `tokenId` or `id`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -35,32 +35,22 @@ The provided interfaces with errors SHOULD conform with the [error grammar rules
 
 This EIP defines standard errors that may be used by implementations in certain scenarios, but does not specify whether implementations should revert in those scenarios, which remains up to the implementers, unless a revert is mandated by the corresponding EIPs.
 
+The names of the error arguments follow the [parameter glossary](#parameter-glossary) section, defining a clear guideline for assigning values to them.
+
 ### [EIP-20](./eip-20.md)
 
 #### `ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)`
 
-Indicates an error related to the current `balance` of a sender in a transfer.
-
-##### Parameters
-
-- `address sender`: The address of whose tokens are transferred from.
-- `uint256 balance`: The current amount of token the sender has.
-- `uint256 needed`: The amount of token the sender needs to perform the operation.
-
-Used when the cause of failure is the balance of a sender.
+Indicates an error related to the current `balance` of a `sender`.
+Used in transfers.
 
 - MUST be used when `balance` is less than `needed`.
 - MUST NOT be used if `balance` is equal or greater than `needed`.
 
 #### `ERC20InvalidSender(address sender)`
 
-Indicates a failure with the token sender.
-
-##### Parameters
-
-- `address sender`: The address of whose tokens are transferred from.
-
-Used when the cause of failure is the sender in a transfer.
+Indicates a failure with the token `sender`.
+Used in transfers.
 
 - MUST be used for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
@@ -69,13 +59,8 @@ Used when the cause of failure is the sender in a transfer.
 
 #### `ERC20InvalidReceiver(address receiver)`
 
-Indicates a failure with the token receiver.
-
-##### Parameters
-
-- `address receiver` The address of whose tokens are transferred to.
-
-Used when the cause of failure is the receiver in a transfer.
+Indicates a failure with the token `receiver`.
+Used in transfers
 
 - MUST be used for disallowed transfers to the zero address.
 - MUST be used for disallowed transfers to non-compatible addresses (eg. contract addresses).
@@ -83,15 +68,8 @@ Used when the cause of failure is the receiver in a transfer.
 
 #### `ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)`
 
-Indicates a failure with the `spender`'s `allowance` in a transfer.
-
-##### Parameters
-
-- `address spender`: The address of who's spending the tokens.
-- `uint256 allowance`: The current amount of tokens a spender can use.
-- `uint256 needed`: The allowance needed to perform the operation.
-
-Used when the cause of failure is the spender's allowance.
+Indicates a failure with the `spender`'s `allowance`.
+Used in transfers.
 
 - MUST be used when `allowance` is less than `needed`.
 - MUST NOT be used if `allowance` is equal or greater than `needed`.
@@ -99,12 +77,7 @@ Used when the cause of failure is the spender's allowance.
 #### `ERC20InvalidApprover(address approver)`
 
 Indicates a failure with the `approver` of a token to be approved.
-
-##### Parameters
-
-- `address approver`: The owner's of the tokens to be approved.
-
-Used when the cause of failure is the owner of the tokens to be approved.
+Used in approvals.
 
 - MUST be used for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
@@ -112,12 +85,7 @@ Used when the cause of failure is the owner of the tokens to be approved.
 #### `ERC20InvalidSpender(address spender)`
 
 Indicates a failure with the `spender` to be approved.
-
-##### Parameters
-
-- `address spender` The address of who's getting owner's approval.
-
-Used when the cause of failure is the spender to be approved.
+Used in approvals.
 
 - MUST be used for disallowed approvals to the zero address.
 - MUST be used for disallowed approvals to the owner itself.
@@ -129,13 +97,7 @@ Used when the cause of failure is the spender to be approved.
 #### `ERC721InvalidOwner(address sender, uint256 tokenId)`
 
 Indicates an error related to the ownership over a particular token.
-
-##### Parameters
-
-- `address sender`: The address of whose token is transferred from.
-- `uint256 tokenId`: The id of the token to be transferred.
-
-Used when the cause of failure is the ownership of a token.
+Used in transfers.
 
 - MUST be used when `ownerOf(tokenId)` is not `sender`.
 - MUST NOT be used for approval operations.
@@ -143,12 +105,7 @@ Used when the cause of failure is the ownership of a token.
 #### `ERC721InvalidSender(address sender)`
 
 Indicates a failure with the token sender.
-
-##### Parameters
-
-- `address sender`: The address of whose token is transferred from.
-
-Used when the cause of failure is the sender in a transfer.
+Used in transfers.
 
 - MUST be used for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
@@ -158,12 +115,7 @@ Used when the cause of failure is the sender in a transfer.
 #### `ERC721InvalidReceiver(address receiver)`
 
 Indicates a failure with the token receiver.
-
-##### Parameters
-
-- `address receiver`: The address of whose token is transferred to.
-
-Used when the cause of failure is the receiver in a transfer.
+Used in transfers.
 
 - MUST be used for disallowed transfers to the zero address.
 - MUST be used for disallowed transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
@@ -171,14 +123,8 @@ Used when the cause of failure is the receiver in a transfer.
 
 #### `ERC721InsufficientApproval(address operator, uint256 tokenId)`
 
-Indicates a failure with the `operator`'s approval in a transfer.
-
-##### Parameters
-
-- `address operator`: The address of who's transferring a token.
-- `uint256 tokenId`: The token to be transferred.
-
-Used when the cause of failure is the operator's approval.
+Indicates a failure with the `operator`'s approval.
+Used in transfers.
 
 - MUST be used when operator `isApprovedForAll(owner, operator)` is false.
 - MUST be used when operator `getApproved(tokenId)` is not `operator`.
@@ -186,12 +132,7 @@ Used when the cause of failure is the operator's approval.
 #### `ERC721InvalidApprover(address approver)`
 
 Indicates a failure with the `owner` of a token to be approved.
-
-##### Parameters
-
-- `address approver`: The owner's of the token to be approved.
-
-Used when the cause of failure is the owner of the tokens to be approved.
+Used in approvals.
 
 - MUST be used for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
@@ -199,12 +140,7 @@ Used when the cause of failure is the owner of the tokens to be approved.
 #### `ERC721InvalidOperator(address operator)`
 
 Indicates a failure with the `operator` to be approved.
-
-##### Parameters
-
-- `address operator`: The address of who's getting owner's approval.
-
-Used when the cause of failure is the spender to be approved.
+Used in approvals.
 
 - MUST be used for disallowed approvals to the zero address.
 - MUST be used for disallowed approvals to the owner itself.
@@ -215,16 +151,8 @@ Used when the cause of failure is the spender to be approved.
 
 #### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id)`
 
-Indicates an error related to the current `balance` of a sender in a transfer.
-
-##### Parameters
-
-- `address sender`: The address of whose tokens are transferred from.
-- `uint256 balance`: The current amount of token the sender has.
-- `uint256 needed`: The amount of token the sender needs to perform the operation.
-- `uint256 id`: The id of the token.
-
-Used when the cause of failure is the balance of a sender.
+Indicates an error related to the current `balance` of a sender.
+Used in transfers.
 
 - MUST be used when `balance` is less than `needed` for an `id`.
 - MUST NOT be used if `balance` is equal or greater than `needed` for an `id`.
@@ -232,12 +160,7 @@ Used when the cause of failure is the balance of a sender.
 #### `ERC1155InvalidSender(address sender)`
 
 Indicates a failure with the token sender.
-
-##### Parameters
-
-- `address sender`: The address of whose tokens are transferred from.
-
-Used when the cause of failure is the sender in a transfer.
+Used in transfers.
 
 - MUST be used for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
@@ -247,12 +170,7 @@ Used when the cause of failure is the sender in a transfer.
 #### `ERC1155InvalidReceiver(address receiver)`
 
 Indicates a failure with the token receiver.
-
-##### Parameters
-
-- `address receiver` The address of whose tokens are transferred to.
-
-Used when the cause of failure is the receiver in a transfer.
+Used in transfers.
 
 - MUST be used for disallowed transfers to the zero address.
 - MUST be used for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
@@ -261,25 +179,14 @@ Used when the cause of failure is the receiver in a transfer.
 #### `ERC1155InsufficientApproval(address operator, uint256 id)`
 
 Indicates a failure with the `operator`'s approval in a transfer.
-
-##### Parameters
-
-- `address operator`: The address of who's transferring a token.
-- `uint256 id`: The token to be transferred.
-
-Used when the cause of failure is the operator's approval.
+Used in transfers.
 
 - MUST be used when operator `isApprovedForAll(owner, operator, id)` is false.
 
 #### `ERC1155InvalidApprover(address approver)`
 
 Indicates a failure with the `approver` of a token to be approved.
-
-##### Parameters
-
-- `address approver`: The owner's of the tokens to be approved.
-
-Used when the cause of failure is the owner of the tokens to be approved.
+Used in approvals.
 
 - MUST be used for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
@@ -287,17 +194,27 @@ Used when the cause of failure is the owner of the tokens to be approved.
 #### `ERC1155InvalidOperator(address operator)`
 
 Indicates a failure with the `operator` to be approved.
-
-##### Parameters
-
-- `address operator`: The address of who's getting owner's approval.
-
-Used when the cause of failure is the spender to be approved.
+Used in approvals.
 
 - MUST be used for disallowed approvals to the zero address.
 - MUST be used for disallowed approvals to the owner itself.
 - MUST NOT be used for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
+
+### Parameter Glossary
+
+| Name        | Description                                                                         |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `sender`    | The address of whose token(s) (is/are) transferred from.                            |
+| `balance`   | Current balance for the interacting account.                                        |
+| `needed`    | Amount minimum required to perform an action.                                       |
+| `receiver`  | Address owner of the token(s) transferred.                                          |
+| `spender`   | Address not owner of the token(s) transferred, but allowed to operate on (it/them). |
+| `allowance` | Amount of token(s) a `spender` is allowed to operate with.                          |
+| `approver`  | Owner of the token(s) being approved to an `spender`.                               |
+| `tokenId`   | The identifier number of a token type.                                              |
+| `operator`  | Same as `spender`.                                                                  |
+| `id`        | Same as `tokenId`.                                                                  |
 
 ### Error additions
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -58,7 +58,7 @@ Used in transfers.
 #### `ERC20InvalidReceiver(address receiver)`
 
 Indicates a failure with the token `receiver`.
-Used in transfers
+Used in transfers.
 
 - MUST be used for disallowed transfers to the zero address.
 - MUST be used for disallowed transfers to non-compatible addresses (eg. contract addresses).

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -97,7 +97,7 @@ Used in approvals.
 Indicates an error related to the ownership over a particular token.
 Used in transfers.
 
-- MUST be used when `ownerOf(tokenId)` is not `sender`.
+- MUST be used when `sender` is not `owner`.
 - MUST NOT be used for approval operations.
 
 #### `ERC721InvalidSender(address sender)`

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -217,8 +217,8 @@ Used in batch transfers.
 | `spender`   | Address that may be allowed to operate on tokens without being their owner. |
 | `allowance` | Amount of tokens a `spender` is allowed to operate with.                    |
 | `approver`  | Address initiating an approval operation.                                   |
-| `tokenId`   | The identifier number of a token.                                           |
-| `owner`     | Address of the owner of a token.                                            |
+| `tokenId`   | Identifier number of a token.                                               |
+| `owner`     | Address of the current owner of a token.                                    |
 | `operator`  | Same as `spender`.                                                          |
 | `*Length`   | Array length for the prefixed parameter.                                    |
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -318,7 +318,7 @@ Where:
 
 ## Backwards Compatibility
 
-<!-- All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright. -->
+Tokens already deployed rely mostly on revert strings and make use of `require` instead of custom errors. Even most of the new deployed tokens since Solidity's v0.8.4 release inherit from implementations using revert strings.
 
 This EIP can not be enforced on non-upgradeable already deployed tokens, however, these tokens generally use similar conventions with small variations such as:
 
@@ -332,8 +332,6 @@ Upgradeable contracts MAY be upgraded to implement this EIP.
 Implementers and DApp developers SHOULD expect these EIP errors to be present on new deployed contracts, but SHOULD handle variation errors for existing contracts, and revert strings that may be returned.
 
 ## Reference Implementation
-
-<!-- An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification. If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/eip-####/`. -->
 
 ### Solidity
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -38,7 +38,6 @@ It's important to note that errors MAY be thrown in each scenario, but that's up
 This EIP aims to provide a clear standard only in case an error will be thrown.
 
 ```solidity
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 /// @title Standard ERC20 Errors
@@ -47,28 +46,19 @@ pragma solidity ^0.8.4;
 interface ERC20Errors {
     /// @notice Indicates a failure with the token sender.
     /// @param _sender The address of whose tokens are transferred from.
-    /// @dev Throw when the cause of failure is the sender in a transfer.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST NOT be thrown for balance or allowance requirements.
-    ///     Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
-    ///  MUST be thrown for unintended transfers from the zero address.
+    /// @dev See [case reference](#erc20invalidsender).
     error ERC20InvalidSender(address _sender);
 
     /// @notice Indicates a failure with the token receiver.
     /// @param _receiver The address of whose tokens are transferred to.
-    /// @dev Throw when the cause of failure is the receiver in a transfer.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST be thrown for unintended transfers to the zero address.
-    ///  MUST be thrown for unintended transfers to non-compatible addresses (eg. contract addresses).
+    /// @dev See [case reference](#erc20invalidreceiver).
     error ERC20InvalidReceiver(address _receiver);
 
     /// @notice Indicates an error related to the current `_balance` of a sender in a transfer.
     /// @param _sender The address of whose tokens are transferred from.
     /// @param _balance The current amount of token the sender has.
     /// @param _needed The amount of token the sender needs to perform the operation.
-    /// @dev Throw when the cause of failure is the balance of a sender.
-    ///  MUST NOT be thrown if `_balance` is equal or greater than `_needed`.
-    ///  MUST be thrown when `_balance` is less than `_needed`.
+    /// @dev See [case reference](#erc20insufficientbalance).
     error ERC20InsufficientBalance(
         address _sender,
         uint256 _balance,
@@ -77,27 +67,19 @@ interface ERC20Errors {
 
     /// @notice Indicates a failure with the `_approver` of a token to be approved.
     /// @param _approver The owner's of the tokens to be approved.
-    /// @dev Throw when the cause of failure is the owner of the tokens to be approved.
-    ///  MUST NOT be thrown for transfer operations.
-    ///  MUST be thrown for unintended approvals from the zero address.
+    /// @dev See [case reference](#erc20invalidapprover).
     error ERC20InvalidApprover(address _approver);
 
     /// @notice Indicates a failure with the `_spender` to be approved.
     /// @param _spender The address of who's getting owner's approval.
-    /// @dev Throw when the cause of failure is the spender to be approved.
-    ///  MUST NOT be thrown for transfer operations.
-    ///     Use `ERC20InsufficientAllowance` instead.
-    ///  MUST be thrown for unintended approvals to the zero address.
-    ///  MUST be thrown for unintended approvals to the owner itself.
+    /// @dev See [case reference](#erc20invalidspender).
     error ERC20InvalidSpender(address _spender);
 
     /// @notice Indicates a failure with the `_spender`'s `_allowance` in a transfer.
     /// @param _spender The address of who's spending the tokens.
     /// @param _allowance The current amount of tokens a spender can use.
     /// @param _needed The allowance needed to perform the operation.
-    /// @dev Throw when the cause of failure is the spender's allowance.
-    ///  MUST NOT be thrown if `_allowance` is equal or greater than `_needed`.
-    ///  MUST be thrown when `_allowance` is less than `_needed`.
+    /// @dev See [case reference](#erc20insufficientallowance).
     error ERC20InsufficientAllowance(
         address _spender,
         uint256 _allowance,
@@ -111,53 +93,34 @@ interface ERC20Errors {
 interface ERC721Errors {
     /// @notice Indicates a failure with the token sender.
     /// @param _sender The address of whose token is transferred from.
-    /// @dev Throw when the cause of failure is the sender in a transfer.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST NOT be thrown for ownership or approval requirements.
-    ///     Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
-    ///  MUST be thrown for unintended transfers from the zero address.
+    /// @dev See [case reference](#erc721invalidsender).
     error ERC721InvalidSender(address _sender);
 
     /// @notice Indicates a failure with the token receiver.
     /// @param _receiver The address of whose token is transferred to.
-    /// @dev Throw when the cause of failure is the receiver in a transfer.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST be thrown for unintended transfers to the zero address.
-    ///  MUST be thrown for unintended transfers to non-ERC721TokenReceiver contracts
-    ///     or those that reject a transfer.
-    ///     (eg. returning an invalid response in `onERC721Received`)
+    /// @dev See [case reference](#erc721invalidreceiver).
     error ERC721InvalidReceiver(address _receiver);
 
     /// @notice Indicates an error related to the ownership over a particular token.
     /// @param _sender The address of whose token is transferred from.
     /// @param _tokenId The id of the token to be transferred.
-    /// @dev Throw when the cause of failure is the ownership of a token.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST be thrown when `ownerOf(_tokenId)` is not `_sender`.
+    /// @dev See [case reference](#erc721invalidowner).
     error ERC721InvalidOwner(address _sender, uint256 _tokenId);
 
     /// @notice Indicates a failure with the `_owner` of a token to be approved.
     /// @param _approver The owner's of the token to be approved.
-    /// @dev Throw when the cause of failure is the owner of the tokens to be approved.
-    ///  MUST NOT be thrown for transfer operations.
-    ///  MUST be thrown for unintended approvals from the zero address.
+    /// @dev See [case reference](#erc721invalidapprover).
     error ERC721InvalidApprover(address _approver);
 
     /// @notice Indicates a failure with the `_operator` to be approved.
     /// @param _operator The address of who's getting owner's approval.
-    /// @dev Throw when the cause of failure is the spender to be approved.
-    ///  MUST NOT be thrown for transfer operations.
-    ///     Use `ERC721InsufficientApproval` instead.
-    ///  MUST be thrown for unintended approvals to the zero address.
-    ///  MUST be thrown for unintended approvals to the owner itself.
+    /// @dev See [case reference](#erc721invalidoperator).
     error ERC721InvalidOperator(address _operator);
 
     /// @notice Indicates a failure with the `_operator`'s approval in a transfer.
     /// @param _operator The address of who's transferring a token.
     /// @param _tokenId The token to be transferred.
-    /// @dev Throw when the cause of failure is the operator's approval.
-    ///  MUST be thrown when operator `isApprovedForAll(_owner, _operator)` is false
-    ///  MUST be thrown when operator `getApproved(_tokenId)` is not `_operator`
+    /// @dev See [case reference](#erc721invalidoperator).
     error ERC721InsufficientApproval(address _operator, uint256 _tokenId);
 }
 
@@ -167,21 +130,12 @@ interface ERC721Errors {
 interface ERC1155Errors {
     /// @notice Indicates a failure with the token sender.
     /// @param _sender The address of whose tokens are transferred from.
-    /// @dev Throw when the cause of failure is the sender in a transfer.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST NOT be thrown for balance or allowance requirements.
-    ///     Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
-    ///  MUST be thrown for unintended transfers from the zero address.
+    /// @dev See [case reference](#erc1155invalidsender).
     error ERC1155InvalidSender(address _sender);
 
     /// @notice Indicates a failure with the token receiver.
     /// @param _receiver The address of whose tokens are transferred to.
-    /// @dev Throw when the cause of failure is the receiver in a transfer.
-    ///  MUST NOT be thrown for approval operations.
-    ///  MUST be thrown for unintended transfers to the zero address.
-    ///  MUST be thrown for unintended transfers to non-ERC1155TokenReceiver contracts
-    ///     or those that reject a transfer.
-    ///     (eg. returning an invalid response in `onERC1155Received`)
+    /// @dev See [case reference](#erc1155invalidreceiver).
     error ERC1155InvalidReceiver(address _receiver);
 
     /// @notice Indicates an error related to the current `_balance` of a sender in a transfer.
@@ -189,9 +143,7 @@ interface ERC1155Errors {
     /// @param _balance The current amount of token the sender has.
     /// @param _needed The amount of token the sender needs to perform the operation.
     /// @param _id The id of the token.
-    /// @dev Throw when the cause of failure is the balance of a sender.
-    ///  MUST NOT be thrown if `_balance` is equal or greater than `_needed` for an `_id`.
-    ///  MUST be thrown when `_balance` is less than `_needed` for an `id`.
+    /// @dev See [case reference](#erc1155insufficientbalance).
     error ERC1155InsufficientBalance(
         address _sender,
         uint256 _balance,
@@ -201,28 +153,167 @@ interface ERC1155Errors {
 
     /// @notice Indicates a failure with the `_approver` of a token to be approved.
     /// @param _approver The owner's of the tokens to be approved.
-    /// @dev Throw when the cause of failure is the owner of the tokens to be approved.
-    ///  MUST NOT be thrown for transfer operations.
-    ///  MUST be thrown for unintended approvals from the zero address.
+    /// @dev See [case reference](#erc1155insufficientbalance).
     error ERC1155InvalidApprover(address _approver);
 
     /// @notice Indicates a failure with the `_operator` to be approved.
     /// @param _operator The address of who's getting owner's approval.
-    /// @dev Throw when the cause of failure is the spender to be approved.
-    ///  MUST NOT be thrown for transfer operations.
-    ///     Use `ERC1155InsufficientApproval` instead.
-    ///  MUST be thrown for unintended approvals to the zero address.
-    ///  MUST be thrown for unintended approvals to the owner itself.
+    /// @dev See [case reference](#erc1155invalidoperator).
     error ERC1155InvalidOperator(address _operator);
 
     /// @notice Indicates a failure with the `_operator`'s approval in a transfer.
     /// @param _operator The address of who's transferring a token.
     /// @param _id The token to be transferred.
-    /// @dev Throw when the cause of failure is the operator's approval.
-    ///  MUST be thrown when operator `isApprovedForAll(_owner, _operator, _id)` is false
+    /// @dev See [case reference](#erc1155insufficientapproval).
     error ERC1155InsufficientApproval(address _operator, uint256 _id);
 }
 ```
+
+### EIP-20
+
+#### ERC20InvalidSender
+
+Throw when the cause of failure is the sender in a transfer.
+
+- MUST NOT be thrown for approval operations.
+- MUST NOT be thrown for balance or allowance requirements.
+  - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
+- MUST be thrown for unintended transfers from the zero address.
+
+#### ERC20InvalidReceiver
+
+Throw when the cause of failure is the receiver in a transfer.
+
+- MUST NOT be thrown for approval operations.
+- MUST be thrown for unintended transfers to the zero address.
+- MUST be thrown for unintended transfers to non-compatible addresses (eg. contract addresses).
+
+#### ERC20InsufficientBalance
+
+Throw when the cause of failure is the balance of a sender.
+
+- MUST NOT be thrown if `_balance` is equal or greater than `_needed`.
+- MUST be thrown when `_balance` is less than `_needed`.
+
+#### ERC20InvalidApprover
+
+Throw when the cause of failure is the owner of the tokens to be approved.
+
+- MUST NOT be thrown for transfer operations.
+- MUST be thrown for unintended approvals from the zero address.
+
+#### ERC20InvalidSpender
+
+Throw when the cause of failure is the spender to be approved.
+
+- MUST NOT be thrown for transfer operations.
+  - Use `ERC20InsufficientAllowance` instead.
+- MUST be thrown for unintended approvals to the zero address.
+- MUST be thrown for unintended approvals to the owner itself.
+
+#### ERC20InsufficientAllowance
+
+Throw when the cause of failure is the spender's allowance.
+
+- MUST NOT be thrown if `_allowance` is equal or greater than `_needed`.
+- MUST be thrown when `_allowance` is less than `_needed`.
+
+### EIP-721
+
+#### ERC721InvalidSender
+
+Throw when the cause of failure is the sender in a transfer.
+
+- MUST NOT be thrown for approval operations.
+- MUST NOT be thrown for ownership or approval requirements.
+  - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
+- MUST be thrown for unintended transfers from the zero address.
+
+#### ERC721InvalidReceiver
+
+Throw when the cause of failure is the receiver in a transfer.
+
+- MUST NOT be thrown for approval operations.
+- MUST be thrown for unintended transfers to the zero address.
+- MUST be thrown for unintended transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
+
+#### ERC721InvalidOwner
+
+Throw when the cause of failure is the ownership of a token.
+
+- MUST NOT be thrown for approval operations.
+- MUST be thrown when `ownerOf(_tokenId)` is not `_sender`.
+
+#### ERC721InvalidApprover
+
+Throw when the cause of failure is the owner of the tokens to be approved.
+
+- MUST NOT be thrown for transfer operations.
+- MUST be thrown for unintended approvals from the zero address.
+
+#### ERC721InvalidOperator
+
+Throw when the cause of failure is the spender to be approved.
+
+- MUST NOT be thrown for transfer operations.
+  - Use `ERC721InsufficientApproval` instead.
+- MUST be thrown for unintended approvals to the zero address.
+- MUST be thrown for unintended approvals to the owner itself.
+
+#### ERC721InsufficientApproval
+
+Throw when the cause of failure is the operator's approval.
+
+- MUST be thrown when operator `isApprovedForAll(_owner, _operator)` is false.
+- MUST be thrown when operator `getApproved(_tokenId)` is not `_operator`.
+
+### EIP-1155
+
+#### ERC1155InvalidSender
+
+Throw when the cause of failure is the sender in a transfer.
+
+- MUST NOT be thrown for approval operations.
+- MUST NOT be thrown for balance or allowance requirements.
+  - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
+- MUST be thrown for unintended transfers from the zero address.
+
+#### ERC1155InvalidReceiver
+
+Throw when the cause of failure is the receiver in a transfer.
+
+- MUST NOT be thrown for approval operations.
+- MUST be thrown for unintended transfers to the zero address.
+- MUST be thrown for unintended transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
+
+#### ERC1155InsufficientBalance
+
+Throw when the cause of failure is the balance of a sender.
+
+- MUST NOT be thrown if `_balance` is equal or greater than `_needed` for an `_id`.
+- MUST be thrown when `_balance` is less than `_needed` for an `id`.
+
+#### ERC1155InvalidApprover
+
+Throw when the cause of failure is the owner of the tokens to be approved.
+
+- MUST NOT be thrown for transfer operations.
+- MUST be thrown for unintended approvals from the zero address.
+
+#### ERC1155InvalidOperator
+
+Throw when the cause of failure is the spender to be approved.
+
+- MUST NOT be thrown for transfer operations.
+  - Use `ERC1155InsufficientApproval` instead.
+- MUST be thrown for unintended approvals to the zero address.
+- MUST be thrown for unintended approvals to the owner itself.
+
+#### ERC1155InsufficientApproval
+
+Throw when the cause of failure is the operator's approval.
+
+- MUST be thrown when operator `isApprovedForAll(_owner, _operator, _id)` is false.
 
 ## Rationale
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -13,7 +13,7 @@ created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 
 ## Abstract
 
-The following specification allows for the use of a standard list of Solidity [custom errors](https://blog.soliditylang.org/2021/04/21/custom-errors/) to be used within EIP-20, EIP-721 and EIP-1155 tokens.
+The following specification allows for the use of a standard list of Solidity [custom errors](https://blog.soliditylang.org/2021/04/21/custom-errors/) to be used within [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens.
 
 Ethereum applications (DApps) and wallets have historically used [revert statements](https://docs.soliditylang.org/en/v0.8.16/control-structures.html#revert-statement) to show relevant failure data to the users, however, this EIP provides a standard list of errors designed to give at least the same relevant information, but in a structured and expected way.
 
@@ -21,7 +21,7 @@ Ethereum applications (DApps) and wallets have historically used [revert stateme
 
 Since the introduction of Solidity custom errors in [v0.8.4](https://github.com/ethereum/solidity/releases/tag/v0.8.4), these have provided a way to show failures in a more expresive way with dynamic arguments, while reducing deployment costs.
 
-At the moment of the release of custom errors, the standard tokens (EIP-20, EIP-721, EIP-1155) were already in finalized state, so no error specification was included.
+At the moment of the release of custom errors, the standard tokens ([EIP-20](./eip-20.md), [EIP-721](./eip-721.md), [EIP-1155](./eip-1155.md)) were already in finalized state, so no error specification was included.
 
 An error specification will allow users to expect more consistent error messages across applications or testing environments, while exposing pertinent arguments and overall reducing the need of writing expensive revert strings in the deployment bytecode.
 
@@ -37,7 +37,7 @@ It's important to note that errors MAY be thrown in each scenario, but that's up
 
 This EIP aims to provide a clear standard only in case an error will be thrown.
 
-### EIP-20
+### [EIP-20](./eip-20.md)
 
 #### `ERC20InvalidSender(address _sender)`
 
@@ -126,7 +126,7 @@ Throw when the cause of failure is the spender's allowance.
 - MUST NOT be thrown if `_allowance` is equal or greater than `_needed`.
 - MUST be thrown when `_allowance` is less than `_needed`.
 
-### EIP-721
+### [EIP-721](./eip-721.md)
 
 #### `ERC721InvalidSender(address _sender)`
 
@@ -213,7 +213,7 @@ Throw when the cause of failure is the operator's approval.
 - MUST be thrown when operator `isApprovedForAll(_owner, _operator)` is false.
 - MUST be thrown when operator `getApproved(_tokenId)` is not `_operator`.
 
-### EIP-1155
+### [EIP-1155](./eip-1155.md)
 
 #### `ERC1155InvalidSender(address _sender)`
 
@@ -490,13 +490,13 @@ interface ERC721Errors {
 /// @dev See https://eips.ethereum.org/EIPS/eip-1155
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC1155Errors {
-    /// @dev See [reference](#erc1155invalidsender).
+    /// @notice See [reference](#erc1155invalidsender).
     error ERC1155InvalidSender(address _sender);
 
-    /// @dev See [reference](#erc1155invalidreceiver).
+    /// @notice See [reference](#erc1155invalidreceiver).
     error ERC1155InvalidReceiver(address _receiver);
 
-    /// @dev See [reference](#erc1155insufficientbalance).
+    /// @notice See [reference](#erc1155insufficientbalance).
     error ERC1155InsufficientBalance(
         address _sender,
         uint256 _balance,
@@ -504,13 +504,13 @@ interface ERC1155Errors {
         uint256 _id
     );
 
-    /// @dev See [reference](#erc1155insufficientbalance).
+    /// @notice See [reference](#erc1155insufficientbalance).
     error ERC1155InvalidApprover(address _approver);
 
-    /// @dev See [reference](#erc1155invalidoperator).
+    /// @notice See [reference](#erc1155invalidoperator).
     error ERC1155InvalidOperator(address _operator);
 
-    /// @dev See [reference](#erc1155insufficientapproval).
+    /// @notice See [reference](#erc1155insufficientapproval).
     error ERC1155InsufficientApproval(address _operator, uint256 _id);
 }
 ```

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -262,7 +262,7 @@ If a subject is called different on a particular token standard, the error MUST 
 
 ### Error prefixes
 
-An error prefix is what complements a subject, so it can be read as an error.
+An error prefix is added to a subject to derive a concrete error condition.
 Developers can think about an error prefix as the _why_ an error happened.
 
 A prefix can be `Invalid` for general incorrectness, or more specific like `Insufficient` for amounts.

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -15,7 +15,7 @@ created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 
 This EIP defines a standard set of Solidity custom errors to be used by [EIP-20](./eip-20.md), [EIP-721](./eip-721.md), and [EIP-1155](./eip-1155.md) tokens.
 
-Ethereum applications (DApps) and wallets have historically relied on revert reason strings to show the cause of transaction errors to users. More recent Solidity versions offer rich revert reasons that require error-specific decoding. This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
+Ethereum applications (DApps) and wallets have historically relied on revert reason strings to show the cause of transaction errors to users. More recent Solidity versions offer rich revert reasons that require error-specific decoding (sometimes referred to as "custom errors"). This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
 
 ## Motivation
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -208,20 +208,20 @@ Used in batch transfers.
 
 ### Parameter Glossary
 
-| Name        | Description                                                                         |
-| ----------- | ----------------------------------------------------------------------------------- |
-| `sender`    | Address whose tokens are being transferred.                                         |
-| `balance`   | Current balance for the interacting account.                                        |
-| `needed`    | Minimum amount required to perform an action.                                       |
-| `receiver`  | Address to which tokens are being transferred.                                      |
-| `spender`   | Address that may be allowed to operate on tokens without being their owner.         |
-| `allowance` | Amount of tokens a `spender` is allowed to operate with.                            |
-| `approver`  | Owner of the token(s) being approved to an `spender`.                               |
-| `tokenId`   | The identifier number of a token type.                                              |
-| `owner`     | Address of the owner of a token type.                                               |
-| `operator`  | Same as `spender`.                                                                  |
-| `id`        | Same as `tokenId`.                                                                  |
-| `*Length`   | Array length for the prefixed parameter.                                            |
+| Name        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `sender`    | Address whose tokens are being transferred.                                 |
+| `balance`   | Current balance for the interacting account.                                |
+| `needed`    | Minimum amount required to perform an action.                               |
+| `receiver`  | Address to which tokens are being transferred.                              |
+| `spender`   | Address that may be allowed to operate on tokens without being their owner. |
+| `allowance` | Amount of tokens a `spender` is allowed to operate with.                    |
+| `approver`  | Address initiating an approval operation.                                   |
+| `tokenId`   | The identifier number of a token type.                                      |
+| `owner`     | Address of the owner of a token type.                                       |
+| `operator`  | Same as `spender`.                                                          |
+| `id`        | Same as `tokenId`.                                                          |
+| `*Length`   | Array length for the prefixed parameter.                                    |
 
 ### Error additions
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -265,7 +265,7 @@ If a subject is called different on a particular token standard, the error MUST 
 An error prefix is what complements a subject, so it can be read as an error.
 Developers can think about an error prefix as the _why_ an error happened.
 
-A prefix can be `Invalid` for general incorrectness, or more specific like `Insufficient` for amounts (or lack of).
+A prefix can be `Invalid` for general incorrectness, or more specific like `Insufficient` for amounts.
 
 ### Domain
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -214,7 +214,7 @@ Used in batch transfers.
 | `balance`   | Current balance for the interacting account.                                        |
 | `needed`    | Minimum amount required to perform an action.                                       |
 | `receiver`  | Address owner of the token(s) transferred.                                          |
-| `spender`   | Address not owner of the token(s) transferred, but allowed to operate on (it/them). |
+| `spender`   | Address that may be allowed to operate on tokens without being their owner.         |
 | `allowance` | Amount of token(s) a `spender` is allowed to operate with.                          |
 | `approver`  | Owner of the token(s) being approved to an `spender`.                               |
 | `tokenId`   | The identifier number of a token type.                                              |

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -224,9 +224,7 @@ Used in batch transfers.
 
 ### Error additions
 
-Any addition to this EIP is considerred a new proposal, but SHOULD follow the guidelines presented in the [rationale](#rationale) section to keep consistency.
-
-Implementation specific errors (such as extensions) SHOULD also follow the same guidelines, although subjects and arguments may vary.
+Any addition to this EIP or implementation-specific errors (such as extensions) SHOULD follow the guidelines presented in the [rationale](#rationale) section to keep consistency.
 
 ## Rationale
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -13,13 +13,13 @@ created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 
 ## Abstract
 
-The following specification allows for the use of a standard list of Solidity [custom errors](https://blog.soliditylang.org/2021/04/21/custom-errors/) to be used within [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens.
+The following specification allows for the use of a standard list of Solidity custom errors to be used within [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens.
 
-Ethereum applications (DApps) and wallets have historically used [revert statements](https://docs.soliditylang.org/en/v0.8.16/control-structures.html#revert-statement) to show relevant failure data to the users, however, this EIP provides a standard list of errors designed to give at least the same relevant information, but in a structured and expected way.
+Ethereum applications (DApps) and wallets have historically used revert statements to show relevant failure data to the users, however, this EIP provides a standard list of errors designed to give at least the same relevant information, but in a structured and expected way.
 
 ## Motivation
 
-Since the introduction of Solidity custom errors in [v0.8.4](https://github.com/ethereum/solidity/releases/tag/v0.8.4), these have provided a way to show failures in a more expresive way with dynamic arguments, while reducing deployment costs.
+Since the introduction of Solidity custom errors in v0.8.4, these have provided a way to show failures in a more expresive way with dynamic arguments, while reducing deployment costs.
 
 At the moment of the release of custom errors, the standard tokens ([EIP-20](./eip-20.md), [EIP-721](./eip-721.md), [EIP-1155](./eip-1155.md)) were already in finalized state, so no error specification was included.
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -39,13 +39,13 @@ This EIP aims to provide a clear standard only in case an error will be thrown.
 
 ### [EIP-20](./eip-20.md)
 
-#### `ERC20InvalidSender(address _sender)`
+#### `ERC20InvalidSender(address)`
 
 Indicates a failure with the token sender.
 
 ##### Parameters
 
-- `_sender`: The address of whose tokens are transferred from.
+- `address _sender`: The address of whose tokens are transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -54,13 +54,13 @@ Throw when the cause of failure is the sender in a transfer.
   - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
 - MUST be thrown for unintended transfers from the zero address.
 
-#### `ERC20InvalidReceiver(address _receiver)`
+#### `ERC20InvalidReceiver(address)`
 
 Indicates a failure with the token receiver.
 
 ##### Parameters
 
-- `receiver` The address of whose tokens are transferred to.
+- `address _receiver` The address of whose tokens are transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -68,41 +68,41 @@ Throw when the cause of failure is the receiver in a transfer.
 - MUST be thrown for unintended transfers to the zero address.
 - MUST be thrown for unintended transfers to non-compatible addresses (eg. contract addresses).
 
-#### `ERC20InsufficientBalance(address _sender, uint256 _balance, uint256 _needed, uint256 _id)`
+#### `ERC20InsufficientBalance(address, uint256, uint256)`
 
 Indicates an error related to the current `_balance` of a sender in a transfer.
 
 ##### Parameters
 
-- `_sender`: The address of whose tokens are transferred from.
-- `_balance`: The current amount of token the sender has.
-- `_needed`: The amount of token the sender needs to perform the operation.
+- `address _sender`: The address of whose tokens are transferred from.
+- `uint256 _balance`: The current amount of token the sender has.
+- `uint256 _needed`: The amount of token the sender needs to perform the operation.
 
 Throw when the cause of failure is the balance of a sender.
 
 - MUST NOT be thrown if `_balance` is equal or greater than `_needed`.
 - MUST be thrown when `_balance` is less than `_needed`.
 
-#### `ERC20InvalidApprover(address _approver)`
+#### `ERC20InvalidApprover(address)`
 
 Indicates a failure with the `_approver` of a token to be approved.
 
 ##### Parameters
 
-- `approver`: The owner's of the tokens to be approved.
+- `address _approver`: The owner's of the tokens to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
 
-#### `ERC20InvalidSpender(address _spender)`
+#### `ERC20InvalidSpender(address)`
 
 Indicates a failure with the `_spender` to be approved.
 
 ##### Parameters
 
-- `_spender` The address of who's getting owner's approval.
+- `address _spender` The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -111,15 +111,15 @@ Throw when the cause of failure is the spender to be approved.
 - MUST be thrown for unintended approvals to the zero address.
 - MUST be thrown for unintended approvals to the owner itself.
 
-#### `ERC20InsufficientAllowance(address _spender, uint256 _allowance, uint256 _needed)`
+#### `ERC20InsufficientAllowance(address, uint256, uint256)`
 
 Indicates a failure with the `_spender`'s `_allowance` in a transfer.
 
 ##### Parameters
 
-- `_spender`: The address of who's spending the tokens.
-- `_allowance`: The current amount of tokens a spender can use.
-- `_needed`: The allowance needed to perform the operation.
+- `address _spender`: The address of who's spending the tokens.
+- `uint256 _allowance`: The current amount of tokens a spender can use.
+- `uint256 _needed`: The allowance needed to perform the operation.
 
 Throw when the cause of failure is the spender's allowance.
 
@@ -128,13 +128,13 @@ Throw when the cause of failure is the spender's allowance.
 
 ### [EIP-721](./eip-721.md)
 
-#### `ERC721InvalidSender(address _sender)`
+#### `ERC721InvalidSender(address)`
 
 Indicates a failure with the token sender.
 
 ##### Parameters
 
-- `_sender`: The address of whose token is transferred from.
+- `address _sender`: The address of whose token is transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -143,13 +143,13 @@ Throw when the cause of failure is the sender in a transfer.
   - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
 - MUST be thrown for unintended transfers from the zero address.
 
-#### `ERC721InvalidReceiver(address _receiver)`
+#### `ERC721InvalidReceiver(address)`
 
 Indicates a failure with the token receiver.
 
 ##### Parameters
 
-- `_receiver`: The address of whose token is transferred to.
+- `address _receiver`: The address of whose token is transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -157,12 +157,12 @@ Throw when the cause of failure is the receiver in a transfer.
 - MUST be thrown for unintended transfers to the zero address.
 - MUST be thrown for unintended transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
 
-#### `ERC721InvalidOwner(address _sender, uint256 _tokenId)`
+#### `ERC721InvalidOwner(address, uint256)`
 
 Indicates an error related to the ownership over a particular token.
 
-- `_sender`: The address of whose token is transferred from.
-- `_tokenId`: The id of the token to be transferred.
+- `address _sender`: The address of whose token is transferred from.
+- `uint256 _tokenId`: The id of the token to be transferred.
 
 ##### Parameters
 
@@ -171,26 +171,26 @@ Throw when the cause of failure is the ownership of a token.
 - MUST NOT be thrown for approval operations.
 - MUST be thrown when `ownerOf(_tokenId)` is not `_sender`.
 
-#### `ERC721InvalidApprover(address _approver)`
+#### `ERC721InvalidApprover(address)`
 
 Indicates a failure with the `_owner` of a token to be approved.
 
 ##### Parameters
 
-- `_approver`: The owner's of the token to be approved.
+- `address _approver`: The owner's of the token to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
 
-#### `ERC721InvalidOperator(address _operator)`
+#### `ERC721InvalidOperator(address)`
 
 Indicates a failure with the `_operator` to be approved.
 
 ##### Parameters
 
-- `_operator`: The address of who's getting owner's approval.
+- `address _operator`: The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -199,14 +199,14 @@ Throw when the cause of failure is the spender to be approved.
 - MUST be thrown for unintended approvals to the zero address.
 - MUST be thrown for unintended approvals to the owner itself.
 
-#### `ERC721InsufficientApproval(address _operator, uint256 _tokenId)`
+#### `ERC721InsufficientApproval(address, uint256)`
 
 Indicates a failure with the `_operator`'s approval in a transfer.
 
 ##### Parameters
 
-- `_operator`: The address of who's transferring a token.
-- `_tokenId`: The token to be transferred.
+- `address _operator`: The address of who's transferring a token.
+- `uint256 _tokenId`: The token to be transferred.
 
 Throw when the cause of failure is the operator's approval.
 
@@ -215,13 +215,13 @@ Throw when the cause of failure is the operator's approval.
 
 ### [EIP-1155](./eip-1155.md)
 
-#### `ERC1155InvalidSender(address _sender)`
+#### `ERC1155InvalidSender(address)`
 
 Indicates a failure with the token sender.
 
 ##### Parameters
 
-- `_sender`: The address of whose tokens are transferred from.
+- `address _sender`: The address of whose tokens are transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -230,13 +230,13 @@ Throw when the cause of failure is the sender in a transfer.
   - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
 - MUST be thrown for unintended transfers from the zero address.
 
-#### `ERC1155InvalidReceiver(address _receiver)`
+#### `ERC1155InvalidReceiver(address)`
 
 Indicates a failure with the token receiver.
 
 ##### Parameters
 
-- `_receiver` The address of whose tokens are transferred to.
+- `address _receiver` The address of whose tokens are transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -244,42 +244,42 @@ Throw when the cause of failure is the receiver in a transfer.
 - MUST be thrown for unintended transfers to the zero address.
 - MUST be thrown for unintended transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 
-#### `ERC1155InsufficientBalance(address _sender, uint256 _balance, uint256 _needed, uint256 _id)`
+#### `ERC1155InsufficientBalance(address, uint256, uint256, uint256)`
 
 Indicates an error related to the current `_balance` of a sender in a transfer.
 
 ##### Parameters
 
-- `_sender`: The address of whose tokens are transferred from.
-- `_balance`: The current amount of token the sender has.
-- `_needed`: The amount of token the sender needs to perform the operation.
-- `_id`: The id of the token.
+- `address _sender`: The address of whose tokens are transferred from.
+- `uint256 _balance`: The current amount of token the sender has.
+- `uint256 _needed`: The amount of token the sender needs to perform the operation.
+- `uint256 _id`: The id of the token.
 
 Throw when the cause of failure is the balance of a sender.
 
 - MUST NOT be thrown if `_balance` is equal or greater than `_needed` for an `_id`.
 - MUST be thrown when `_balance` is less than `_needed` for an `id`.
 
-#### `ERC1155InvalidApprover(address _approver)`
+#### `ERC1155InvalidApprover(address)`
 
 Indicates a failure with the `_approver` of a token to be approved.
 
 ##### Parameters
 
-- `_approver`: The owner's of the tokens to be approved.
+- `address _approver`: The owner's of the tokens to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
 
-#### `ERC1155InvalidOperator(address _operator)`
+#### `ERC1155InvalidOperator(address)`
 
 Indicates a failure with the `_operator` to be approved.
 
 ##### Parameters
 
-- `_operator`: The address of who's getting owner's approval.
+- `address _operator`: The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -288,14 +288,14 @@ Throw when the cause of failure is the spender to be approved.
 - MUST be thrown for unintended approvals to the zero address.
 - MUST be thrown for unintended approvals to the owner itself.
 
-#### `ERC1155InsufficientApproval(address _operator, uint256 _id)`
+#### `ERC1155InsufficientApproval(address, uint256)`
 
 Indicates a failure with the `_operator`'s approval in a transfer.
 
 ##### Parameters
 
-- `_operator`: The address of who's transferring a token.
-- `_id`: The token to be transferred.
+- `address _operator`: The address of who's transferring a token.
+- `uint256 _id`: The token to be transferred.
 
 Throw when the cause of failure is the operator's approval.
 
@@ -438,29 +438,16 @@ pragma solidity ^0.8.4;
 interface ERC20Errors {
     /// @notice See [reference](#erc20invalidsender).
     error ERC20InvalidSender(address _sender);
-
     /// @notice See [reference](#erc20invalidreceiver).
     error ERC20InvalidReceiver(address _receiver);
-
     /// @notice See [reference](#erc20insufficientbalance).
-    error ERC20InsufficientBalance(
-        address _sender,
-        uint256 _balance,
-        uint256 _needed
-    );
-
+    error ERC20InsufficientBalance(address _sender, uint256 _balance, uint256 _needed);
     /// @notice See [reference](#erc20invalidapprover).
     error ERC20InvalidApprover(address _approver);
-
     /// @notice See [reference](#erc20invalidspender).
     error ERC20InvalidSpender(address _spender);
-
     /// @notice See [reference](#erc20insufficientallowance).
-    error ERC20InsufficientAllowance(
-        address _spender,
-        uint256 _allowance,
-        uint256 _needed
-    );
+    error ERC20InsufficientAllowance(address _spender, uint256 _allowance, uint256 _needed);
 }
 
 /// @title Standard ERC721 Errors
@@ -469,20 +456,15 @@ interface ERC20Errors {
 interface ERC721Errors {
     /// @notice See [reference](#erc721invalidsender).
     error ERC721InvalidSender(address _sender);
-
     /// @notice See [reference](#erc721invalidreceiver).
     error ERC721InvalidReceiver(address _receiver);
-
     /// @notice See [reference](#erc721invalidowner).
     error ERC721InvalidOwner(address _sender, uint256 _tokenId);
-
     /// @notice See [reference](#erc721invalidapprover).
     error ERC721InvalidApprover(address _approver);
-
     /// @notice See [reference](#erc721invalidoperator).
     error ERC721InvalidOperator(address _operator);
-
-    /// @notice See [reference](#erc721invalidoperator).
+    /// @notice See [reference](#erc721insufficientapproval).
     error ERC721InsufficientApproval(address _operator, uint256 _tokenId);
 }
 
@@ -492,24 +474,14 @@ interface ERC721Errors {
 interface ERC1155Errors {
     /// @notice See [reference](#erc1155invalidsender).
     error ERC1155InvalidSender(address _sender);
-
     /// @notice See [reference](#erc1155invalidreceiver).
     error ERC1155InvalidReceiver(address _receiver);
-
     /// @notice See [reference](#erc1155insufficientbalance).
-    error ERC1155InsufficientBalance(
-        address _sender,
-        uint256 _balance,
-        uint256 _needed,
-        uint256 _id
-    );
-
-    /// @notice See [reference](#erc1155insufficientbalance).
+    error ERC1155InsufficientBalance(address _sender, uint256 _balance, uint256 _needed, uint256 _id);
+    /// @notice See [reference](#erc1155invalidapprover).
     error ERC1155InvalidApprover(address _approver);
-
     /// @notice See [reference](#erc1155invalidoperator).
     error ERC1155InvalidOperator(address _operator);
-
     /// @notice See [reference](#erc1155insufficientapproval).
     error ERC1155InsufficientApproval(address _operator, uint256 _id);
 }

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -269,7 +269,7 @@ A prefix can be `Invalid` for general incorrectness, or more specific like `Insu
 
 ### Domain
 
-Although these errors are considered to be expressive enough, each error's arguments may vary depending on the token domain, causing a `DeclarationError` if there are errors with the same name and different arguments.
+Each error's arguments may vary depending on the token domain. If there are errors with the same name and different arguments, the Solidity compiler currently fails with a `DeclarationError`.
 
 An example of this is:
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -1,8 +1,8 @@
 ---
 eip: [assignedEIPNumber]
-title: Standard Token Errors
+title: Custom errors for ERC tokens
 description: List of Solidity custom errors covering standard token implementations (EIP-20, EIP-721 and EIP-1155)
-author: Francisco Giordano (@frangio), Ernesto García (@ernestognw)
+author: Ernesto García (@ernestognw), Francisco Giordano (@frangio), Hadrien Croubois (@Amxx)
 discussions-to: <URL>
 status: Draft
 type: Standards Track
@@ -364,4 +364,4 @@ Copyright and related rights waived via [CC0](../LICENSE.md).
 
 Please cite this document as:
 
-Francisco Giordano, Ernesto García, "EIP-[assignedEIPNumber]: Standard Token Errors [DRAFT]," Ethereum Improvement Proposals, no. [assignedEIPNumber], November 2022. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber].
+Ernesto García, Francisco Giordano, Hadrien Croubois, "EIP-[assignedEIPNumber]: Standard Token Errors [DRAFT]," Ethereum Improvement Proposals, no. [assignedEIPNumber], November 2022. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber].

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -37,141 +37,15 @@ It's important to note that errors MAY be thrown in each scenario, but that's up
 
 This EIP aims to provide a clear standard only in case an error will be thrown.
 
-```solidity
-pragma solidity ^0.8.4;
-
-/// @title Standard ERC20 Errors
-/// @dev See https://eips.ethereum.org/EIPS/eip-20
-///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
-interface ERC20Errors {
-    /// @notice Indicates a failure with the token sender.
-    /// @param _sender The address of whose tokens are transferred from.
-    /// @dev See [case reference](#erc20invalidsender).
-    error ERC20InvalidSender(address _sender);
-
-    /// @notice Indicates a failure with the token receiver.
-    /// @param _receiver The address of whose tokens are transferred to.
-    /// @dev See [case reference](#erc20invalidreceiver).
-    error ERC20InvalidReceiver(address _receiver);
-
-    /// @notice Indicates an error related to the current `_balance` of a sender in a transfer.
-    /// @param _sender The address of whose tokens are transferred from.
-    /// @param _balance The current amount of token the sender has.
-    /// @param _needed The amount of token the sender needs to perform the operation.
-    /// @dev See [case reference](#erc20insufficientbalance).
-    error ERC20InsufficientBalance(
-        address _sender,
-        uint256 _balance,
-        uint256 _needed
-    );
-
-    /// @notice Indicates a failure with the `_approver` of a token to be approved.
-    /// @param _approver The owner's of the tokens to be approved.
-    /// @dev See [case reference](#erc20invalidapprover).
-    error ERC20InvalidApprover(address _approver);
-
-    /// @notice Indicates a failure with the `_spender` to be approved.
-    /// @param _spender The address of who's getting owner's approval.
-    /// @dev See [case reference](#erc20invalidspender).
-    error ERC20InvalidSpender(address _spender);
-
-    /// @notice Indicates a failure with the `_spender`'s `_allowance` in a transfer.
-    /// @param _spender The address of who's spending the tokens.
-    /// @param _allowance The current amount of tokens a spender can use.
-    /// @param _needed The allowance needed to perform the operation.
-    /// @dev See [case reference](#erc20insufficientallowance).
-    error ERC20InsufficientAllowance(
-        address _spender,
-        uint256 _allowance,
-        uint256 _needed
-    );
-}
-
-/// @title Standard ERC721 Errors
-/// @dev See https://eips.ethereum.org/EIPS/eip-721
-///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
-interface ERC721Errors {
-    /// @notice Indicates a failure with the token sender.
-    /// @param _sender The address of whose token is transferred from.
-    /// @dev See [case reference](#erc721invalidsender).
-    error ERC721InvalidSender(address _sender);
-
-    /// @notice Indicates a failure with the token receiver.
-    /// @param _receiver The address of whose token is transferred to.
-    /// @dev See [case reference](#erc721invalidreceiver).
-    error ERC721InvalidReceiver(address _receiver);
-
-    /// @notice Indicates an error related to the ownership over a particular token.
-    /// @param _sender The address of whose token is transferred from.
-    /// @param _tokenId The id of the token to be transferred.
-    /// @dev See [case reference](#erc721invalidowner).
-    error ERC721InvalidOwner(address _sender, uint256 _tokenId);
-
-    /// @notice Indicates a failure with the `_owner` of a token to be approved.
-    /// @param _approver The owner's of the token to be approved.
-    /// @dev See [case reference](#erc721invalidapprover).
-    error ERC721InvalidApprover(address _approver);
-
-    /// @notice Indicates a failure with the `_operator` to be approved.
-    /// @param _operator The address of who's getting owner's approval.
-    /// @dev See [case reference](#erc721invalidoperator).
-    error ERC721InvalidOperator(address _operator);
-
-    /// @notice Indicates a failure with the `_operator`'s approval in a transfer.
-    /// @param _operator The address of who's transferring a token.
-    /// @param _tokenId The token to be transferred.
-    /// @dev See [case reference](#erc721invalidoperator).
-    error ERC721InsufficientApproval(address _operator, uint256 _tokenId);
-}
-
-/// @title Standard ERC1155 Errors
-/// @dev See https://eips.ethereum.org/EIPS/eip-1155
-///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
-interface ERC1155Errors {
-    /// @notice Indicates a failure with the token sender.
-    /// @param _sender The address of whose tokens are transferred from.
-    /// @dev See [case reference](#erc1155invalidsender).
-    error ERC1155InvalidSender(address _sender);
-
-    /// @notice Indicates a failure with the token receiver.
-    /// @param _receiver The address of whose tokens are transferred to.
-    /// @dev See [case reference](#erc1155invalidreceiver).
-    error ERC1155InvalidReceiver(address _receiver);
-
-    /// @notice Indicates an error related to the current `_balance` of a sender in a transfer.
-    /// @param _sender The address of whose tokens are transferred from.
-    /// @param _balance The current amount of token the sender has.
-    /// @param _needed The amount of token the sender needs to perform the operation.
-    /// @param _id The id of the token.
-    /// @dev See [case reference](#erc1155insufficientbalance).
-    error ERC1155InsufficientBalance(
-        address _sender,
-        uint256 _balance,
-        uint256 _needed,
-        uint256 _id
-    );
-
-    /// @notice Indicates a failure with the `_approver` of a token to be approved.
-    /// @param _approver The owner's of the tokens to be approved.
-    /// @dev See [case reference](#erc1155insufficientbalance).
-    error ERC1155InvalidApprover(address _approver);
-
-    /// @notice Indicates a failure with the `_operator` to be approved.
-    /// @param _operator The address of who's getting owner's approval.
-    /// @dev See [case reference](#erc1155invalidoperator).
-    error ERC1155InvalidOperator(address _operator);
-
-    /// @notice Indicates a failure with the `_operator`'s approval in a transfer.
-    /// @param _operator The address of who's transferring a token.
-    /// @param _id The token to be transferred.
-    /// @dev See [case reference](#erc1155insufficientapproval).
-    error ERC1155InsufficientApproval(address _operator, uint256 _id);
-}
-```
-
 ### EIP-20
 
-#### ERC20InvalidSender
+#### `ERC20InvalidSender(address _sender)`
+
+Indicates a failure with the token sender.
+
+##### Parameters
+
+- `_sender`: The address of whose tokens are transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -180,7 +54,13 @@ Throw when the cause of failure is the sender in a transfer.
   - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
 - MUST be thrown for unintended transfers from the zero address.
 
-#### ERC20InvalidReceiver
+#### `ERC20InvalidReceiver(address _receiver)`
+
+Indicates a failure with the token receiver.
+
+##### Parameters
+
+- `receiver` The address of whose tokens are transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -188,21 +68,41 @@ Throw when the cause of failure is the receiver in a transfer.
 - MUST be thrown for unintended transfers to the zero address.
 - MUST be thrown for unintended transfers to non-compatible addresses (eg. contract addresses).
 
-#### ERC20InsufficientBalance
+#### `ERC20InsufficientBalance(address _sender, uint256 _balance, uint256 _needed, uint256 _id)`
+
+Indicates an error related to the current `_balance` of a sender in a transfer.
+
+##### Parameters
+
+- `_sender`: The address of whose tokens are transferred from.
+- `_balance`: The current amount of token the sender has.
+- `_needed`: The amount of token the sender needs to perform the operation.
 
 Throw when the cause of failure is the balance of a sender.
 
 - MUST NOT be thrown if `_balance` is equal or greater than `_needed`.
 - MUST be thrown when `_balance` is less than `_needed`.
 
-#### ERC20InvalidApprover
+#### `ERC20InvalidApprover(address _approver)`
+
+Indicates a failure with the `_approver` of a token to be approved.
+
+##### Parameters
+
+- `approver`: The owner's of the tokens to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
 
-#### ERC20InvalidSpender
+#### `ERC20InvalidSpender(address _spender)`
+
+Indicates a failure with the `_spender` to be approved.
+
+##### Parameters
+
+- `_spender` The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -211,7 +111,15 @@ Throw when the cause of failure is the spender to be approved.
 - MUST be thrown for unintended approvals to the zero address.
 - MUST be thrown for unintended approvals to the owner itself.
 
-#### ERC20InsufficientAllowance
+#### `ERC20InsufficientAllowance(address _spender, uint256 _allowance, uint256 _needed)`
+
+Indicates a failure with the `_spender`'s `_allowance` in a transfer.
+
+##### Parameters
+
+- `_spender`: The address of who's spending the tokens.
+- `_allowance`: The current amount of tokens a spender can use.
+- `_needed`: The allowance needed to perform the operation.
 
 Throw when the cause of failure is the spender's allowance.
 
@@ -220,7 +128,13 @@ Throw when the cause of failure is the spender's allowance.
 
 ### EIP-721
 
-#### ERC721InvalidSender
+#### `ERC721InvalidSender(address _sender)`
+
+Indicates a failure with the token sender.
+
+##### Parameters
+
+- `_sender`: The address of whose token is transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -229,7 +143,13 @@ Throw when the cause of failure is the sender in a transfer.
   - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
 - MUST be thrown for unintended transfers from the zero address.
 
-#### ERC721InvalidReceiver
+#### `ERC721InvalidReceiver(address _receiver)`
+
+Indicates a failure with the token receiver.
+
+##### Parameters
+
+- `_receiver`: The address of whose token is transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -237,21 +157,40 @@ Throw when the cause of failure is the receiver in a transfer.
 - MUST be thrown for unintended transfers to the zero address.
 - MUST be thrown for unintended transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
 
-#### ERC721InvalidOwner
+#### `ERC721InvalidOwner(address _sender, uint256 _tokenId)`
+
+Indicates an error related to the ownership over a particular token.
+
+- `_sender`: The address of whose token is transferred from.
+- `_tokenId`: The id of the token to be transferred.
+
+##### Parameters
 
 Throw when the cause of failure is the ownership of a token.
 
 - MUST NOT be thrown for approval operations.
 - MUST be thrown when `ownerOf(_tokenId)` is not `_sender`.
 
-#### ERC721InvalidApprover
+#### `ERC721InvalidApprover(address _approver)`
+
+Indicates a failure with the `_owner` of a token to be approved.
+
+##### Parameters
+
+- `_approver`: The owner's of the token to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
 
-#### ERC721InvalidOperator
+#### `ERC721InvalidOperator(address _operator)`
+
+Indicates a failure with the `_operator` to be approved.
+
+##### Parameters
+
+- `_operator`: The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -260,7 +199,14 @@ Throw when the cause of failure is the spender to be approved.
 - MUST be thrown for unintended approvals to the zero address.
 - MUST be thrown for unintended approvals to the owner itself.
 
-#### ERC721InsufficientApproval
+#### `ERC721InsufficientApproval(address _operator, uint256 _tokenId)`
+
+Indicates a failure with the `_operator`'s approval in a transfer.
+
+##### Parameters
+
+- `_operator`: The address of who's transferring a token.
+- `_tokenId`: The token to be transferred.
 
 Throw when the cause of failure is the operator's approval.
 
@@ -269,7 +215,13 @@ Throw when the cause of failure is the operator's approval.
 
 ### EIP-1155
 
-#### ERC1155InvalidSender
+#### `ERC1155InvalidSender(address _sender)`
+
+Indicates a failure with the token sender.
+
+##### Parameters
+
+- `_sender`: The address of whose tokens are transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -278,7 +230,13 @@ Throw when the cause of failure is the sender in a transfer.
   - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
 - MUST be thrown for unintended transfers from the zero address.
 
-#### ERC1155InvalidReceiver
+#### `ERC1155InvalidReceiver(address _receiver)`
+
+Indicates a failure with the token receiver.
+
+##### Parameters
+
+- `_receiver` The address of whose tokens are transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -286,21 +244,42 @@ Throw when the cause of failure is the receiver in a transfer.
 - MUST be thrown for unintended transfers to the zero address.
 - MUST be thrown for unintended transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 
-#### ERC1155InsufficientBalance
+#### `ERC1155InsufficientBalance(address _sender, uint256 _balance, uint256 _needed, uint256 _id)`
+
+Indicates an error related to the current `_balance` of a sender in a transfer.
+
+##### Parameters
+
+- `_sender`: The address of whose tokens are transferred from.
+- `_balance`: The current amount of token the sender has.
+- `_needed`: The amount of token the sender needs to perform the operation.
+- `_id`: The id of the token.
 
 Throw when the cause of failure is the balance of a sender.
 
 - MUST NOT be thrown if `_balance` is equal or greater than `_needed` for an `_id`.
 - MUST be thrown when `_balance` is less than `_needed` for an `id`.
 
-#### ERC1155InvalidApprover
+#### `ERC1155InvalidApprover(address _approver)`
+
+Indicates a failure with the `_approver` of a token to be approved.
+
+##### Parameters
+
+- `_approver`: The owner's of the tokens to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
 
-#### ERC1155InvalidOperator
+#### `ERC1155InvalidOperator(address _operator)`
+
+Indicates a failure with the `_operator` to be approved.
+
+##### Parameters
+
+- `_operator`: The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -309,7 +288,14 @@ Throw when the cause of failure is the spender to be approved.
 - MUST be thrown for unintended approvals to the zero address.
 - MUST be thrown for unintended approvals to the owner itself.
 
-#### ERC1155InsufficientApproval
+#### `ERC1155InsufficientApproval(address _operator, uint256 _id)`
+
+Indicates a failure with the `_operator`'s approval in a transfer.
+
+##### Parameters
+
+- `_operator`: The address of who's transferring a token.
+- `_id`: The token to be transferred.
 
 Throw when the cause of failure is the operator's approval.
 
@@ -440,6 +426,94 @@ Implementers and DApp developers SHOULD expect these EIP errors to be present on
 ## Reference Implementation
 
 <!-- An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification. If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/eip-####/`. -->
+
+### Solidity
+
+```solidity
+pragma solidity ^0.8.4;
+
+/// @title Standard ERC20 Errors
+/// @dev See https://eips.ethereum.org/EIPS/eip-20
+///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
+interface ERC20Errors {
+    /// @notice See [reference](#erc20invalidsender).
+    error ERC20InvalidSender(address _sender);
+
+    /// @notice See [reference](#erc20invalidreceiver).
+    error ERC20InvalidReceiver(address _receiver);
+
+    /// @notice See [reference](#erc20insufficientbalance).
+    error ERC20InsufficientBalance(
+        address _sender,
+        uint256 _balance,
+        uint256 _needed
+    );
+
+    /// @notice See [reference](#erc20invalidapprover).
+    error ERC20InvalidApprover(address _approver);
+
+    /// @notice See [reference](#erc20invalidspender).
+    error ERC20InvalidSpender(address _spender);
+
+    /// @notice See [reference](#erc20insufficientallowance).
+    error ERC20InsufficientAllowance(
+        address _spender,
+        uint256 _allowance,
+        uint256 _needed
+    );
+}
+
+/// @title Standard ERC721 Errors
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
+interface ERC721Errors {
+    /// @notice See [reference](#erc721invalidsender).
+    error ERC721InvalidSender(address _sender);
+
+    /// @notice See [reference](#erc721invalidreceiver).
+    error ERC721InvalidReceiver(address _receiver);
+
+    /// @notice See [reference](#erc721invalidowner).
+    error ERC721InvalidOwner(address _sender, uint256 _tokenId);
+
+    /// @notice See [reference](#erc721invalidapprover).
+    error ERC721InvalidApprover(address _approver);
+
+    /// @notice See [reference](#erc721invalidoperator).
+    error ERC721InvalidOperator(address _operator);
+
+    /// @notice See [reference](#erc721invalidoperator).
+    error ERC721InsufficientApproval(address _operator, uint256 _tokenId);
+}
+
+/// @title Standard ERC1155 Errors
+/// @dev See https://eips.ethereum.org/EIPS/eip-1155
+///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
+interface ERC1155Errors {
+    /// @dev See [reference](#erc1155invalidsender).
+    error ERC1155InvalidSender(address _sender);
+
+    /// @dev See [reference](#erc1155invalidreceiver).
+    error ERC1155InvalidReceiver(address _receiver);
+
+    /// @dev See [reference](#erc1155insufficientbalance).
+    error ERC1155InsufficientBalance(
+        address _sender,
+        uint256 _balance,
+        uint256 _needed,
+        uint256 _id
+    );
+
+    /// @dev See [reference](#erc1155insufficientbalance).
+    error ERC1155InvalidApprover(address _approver);
+
+    /// @dev See [reference](#erc1155invalidoperator).
+    error ERC1155InvalidOperator(address _operator);
+
+    /// @dev See [reference](#erc1155insufficientapproval).
+    error ERC1155InsufficientApproval(address _operator, uint256 _id);
+}
+```
 
 ## Security Considerations
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -242,7 +242,7 @@ The main actions that can be performed within a token are:
 - **Transfer**: An operation in which a _sender_ moves to a _receiver_ any number of tokens (fungible _balance_ and/or non-fungible _token ids_).
 - **Approval**: An operation in which an _approver_ grants any form of _approval_ to an _operator_.
 
-Whose subjects outlined are expected to be exhaustive to represent _what_ can go wrong in a transaction, which can be shown as an error by adding a [failure prefix](#error-prefixes).
+The subjects outlined above are expected to exhaustively represent _what_ can go wrong in a token transaction, deriving a specific error by adding an [error prefix](#error-prefixes).
 
 Note that `Token` or `TokenID` MUST NOT be a subject for the following reasons:
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -33,9 +33,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 The provided interfaces with errors SHOULD conform with the [error grammar rules](#error-grammar-rules) described in the [rationale](#rationale) section.
 
-It's important to note that errors MAY be thrown in each scenario, but that's up to the implementers, unless a revert reason is specified in their corresponding EIPs.
+It's important to note that errors MAY be used in each scenario, but that's up to the implementers, unless a revert reason is specified in their corresponding EIPs.
 
-This EIP aims to provide a clear standard only in case an error will be thrown.
+This EIP aims to provide a clear standard only in case an error will be used.
 
 ### [EIP-20](./eip-20.md)
 
@@ -49,10 +49,10 @@ Indicates a failure with the token sender.
 
 Used when the cause of failure is the sender in a transfer.
 
-- MUST NOT be thrown for approval operations.
-- MUST NOT be thrown for balance or allowance requirements.
+- MUST be used for disallowed transfers from the zero address.
+- MUST NOT be used for approval operations.
+- MUST NOT be used for balance or allowance requirements.
   - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
-- MUST be thrown for disallowed transfers from the zero address.
 
 #### `ERC20InvalidReceiver(address)`
 
@@ -64,9 +64,9 @@ Indicates a failure with the token receiver.
 
 Used when the cause of failure is the receiver in a transfer.
 
-- MUST NOT be thrown for approval operations.
-- MUST be thrown for disallowed transfers to the zero address.
-- MUST be thrown for disallowed transfers to non-compatible addresses (eg. contract addresses).
+- MUST be used for disallowed transfers to the zero address.
+- MUST be used for disallowed transfers to non-compatible addresses (eg. contract addresses).
+- MUST NOT be used for approval operations.
 
 #### `ERC20InsufficientBalance(address, uint256, uint256)`
 
@@ -80,8 +80,8 @@ Indicates an error related to the current `balance` of a sender in a transfer.
 
 Used when the cause of failure is the balance of a sender.
 
-- MUST NOT be thrown if `balance` is equal or greater than `needed`.
-- MUST be thrown when `balance` is less than `needed`.
+- MUST be used when `balance` is less than `needed`.
+- MUST NOT be used if `balance` is equal or greater than `needed`.
 
 #### `ERC20InvalidApprover(address)`
 
@@ -93,8 +93,8 @@ Indicates a failure with the `approver` of a token to be approved.
 
 Used when the cause of failure is the owner of the tokens to be approved.
 
-- MUST NOT be thrown for transfer operations.
-- MUST be thrown for disallowed approvals from the zero address.
+- MUST be used for disallowed approvals from the zero address.
+- MUST NOT be used for transfer operations.
 
 #### `ERC20InvalidSpender(address)`
 
@@ -106,10 +106,10 @@ Indicates a failure with the `spender` to be approved.
 
 Used when the cause of failure is the spender to be approved.
 
-- MUST NOT be thrown for transfer operations.
+- MUST be used for disallowed approvals to the zero address.
+- MUST be used for disallowed approvals to the owner itself.
+- MUST NOT be used for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
-- MUST be thrown for disallowed approvals to the zero address.
-- MUST be thrown for disallowed approvals to the owner itself.
 
 #### `ERC20InsufficientAllowance(address, uint256, uint256)`
 
@@ -123,8 +123,8 @@ Indicates a failure with the `spender`'s `allowance` in a transfer.
 
 Used when the cause of failure is the spender's allowance.
 
-- MUST NOT be thrown if `allowance` is equal or greater than `needed`.
-- MUST be thrown when `allowance` is less than `needed`.
+- MUST be used when `allowance` is less than `needed`.
+- MUST NOT be used if `allowance` is equal or greater than `needed`.
 
 ### [EIP-721](./eip-721.md)
 
@@ -138,10 +138,10 @@ Indicates a failure with the token sender.
 
 Used when the cause of failure is the sender in a transfer.
 
-- MUST NOT be thrown for approval operations.
-- MUST NOT be thrown for ownership or approval requirements.
+- MUST be used for disallowed transfers from the zero address.
+- MUST NOT be used for approval operations.
+- MUST NOT be used for ownership or approval requirements.
   - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
-- MUST be thrown for disallowed transfers from the zero address.
 
 #### `ERC721InvalidReceiver(address)`
 
@@ -153,9 +153,9 @@ Indicates a failure with the token receiver.
 
 Used when the cause of failure is the receiver in a transfer.
 
-- MUST NOT be thrown for approval operations.
-- MUST be thrown for disallowed transfers to the zero address.
-- MUST be thrown for disallowed transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
+- MUST be used for disallowed transfers to the zero address.
+- MUST be used for disallowed transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
+- MUST NOT be used for approval operations.
 
 #### `ERC721InvalidOwner(address, uint256)`
 
@@ -168,8 +168,8 @@ Indicates an error related to the ownership over a particular token.
 
 Used when the cause of failure is the ownership of a token.
 
-- MUST NOT be thrown for approval operations.
-- MUST be thrown when `ownerOf(tokenId)` is not `sender`.
+- MUST be used when `ownerOf(tokenId)` is not `sender`.
+- MUST NOT be used for approval operations.
 
 #### `ERC721InvalidApprover(address)`
 
@@ -181,8 +181,8 @@ Indicates a failure with the `owner` of a token to be approved.
 
 Used when the cause of failure is the owner of the tokens to be approved.
 
-- MUST NOT be thrown for transfer operations.
-- MUST be thrown for disallowed approvals from the zero address.
+- MUST be used for disallowed approvals from the zero address.
+- MUST NOT be used for transfer operations.
 
 #### `ERC721InvalidOperator(address)`
 
@@ -194,10 +194,10 @@ Indicates a failure with the `operator` to be approved.
 
 Used when the cause of failure is the spender to be approved.
 
-- MUST NOT be thrown for transfer operations.
+- MUST be used for disallowed approvals to the zero address.
+- MUST be used for disallowed approvals to the owner itself.
+- MUST NOT be used for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
-- MUST be thrown for disallowed approvals to the zero address.
-- MUST be thrown for disallowed approvals to the owner itself.
 
 #### `ERC721InsufficientApproval(address, uint256)`
 
@@ -210,8 +210,8 @@ Indicates a failure with the `operator`'s approval in a transfer.
 
 Used when the cause of failure is the operator's approval.
 
-- MUST be thrown when operator `isApprovedForAll(owner, operator)` is false.
-- MUST be thrown when operator `getApproved(tokenId)` is not `operator`.
+- MUST be used when operator `isApprovedForAll(owner, operator)` is false.
+- MUST be used when operator `getApproved(tokenId)` is not `operator`.
 
 ### [EIP-1155](./eip-1155.md)
 
@@ -225,10 +225,10 @@ Indicates a failure with the token sender.
 
 Used when the cause of failure is the sender in a transfer.
 
-- MUST NOT be thrown for approval operations.
-- MUST NOT be thrown for balance or allowance requirements.
+- MUST be used for disallowed transfers from the zero address.
+- MUST NOT be used for approval operations.
+- MUST NOT be used for balance or allowance requirements.
   - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
-- MUST be thrown for disallowed transfers from the zero address.
 
 #### `ERC1155InvalidReceiver(address)`
 
@@ -240,9 +240,9 @@ Indicates a failure with the token receiver.
 
 Used when the cause of failure is the receiver in a transfer.
 
-- MUST NOT be thrown for approval operations.
-- MUST be thrown for disallowed transfers to the zero address.
-- MUST be thrown for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
+- MUST be used for disallowed transfers to the zero address.
+- MUST be used for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
+- MUST NOT be used for approval operations.
 
 #### `ERC1155InsufficientBalance(address, uint256, uint256, uint256)`
 
@@ -257,8 +257,8 @@ Indicates an error related to the current `balance` of a sender in a transfer.
 
 Used when the cause of failure is the balance of a sender.
 
-- MUST NOT be thrown if `balance` is equal or greater than `needed` for an `id`.
-- MUST be thrown when `balance` is less than `needed` for an `id`.
+- MUST be used when `balance` is less than `needed` for an `id`.
+- MUST NOT be used if `balance` is equal or greater than `needed` for an `id`.
 
 #### `ERC1155InvalidApprover(address)`
 
@@ -270,8 +270,8 @@ Indicates a failure with the `approver` of a token to be approved.
 
 Used when the cause of failure is the owner of the tokens to be approved.
 
-- MUST NOT be thrown for transfer operations.
-- MUST be thrown for disallowed approvals from the zero address.
+- MUST be used for disallowed approvals from the zero address.
+- MUST NOT be used for transfer operations.
 
 #### `ERC1155InvalidOperator(address)`
 
@@ -283,10 +283,10 @@ Indicates a failure with the `operator` to be approved.
 
 Used when the cause of failure is the spender to be approved.
 
-- MUST NOT be thrown for transfer operations.
+- MUST be used for disallowed approvals to the zero address.
+- MUST be used for disallowed approvals to the owner itself.
+- MUST NOT be used for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
-- MUST be thrown for disallowed approvals to the zero address.
-- MUST be thrown for disallowed approvals to the owner itself.
 
 #### `ERC1155InsufficientApproval(address, uint256)`
 
@@ -299,7 +299,7 @@ Indicates a failure with the `operator`'s approval in a transfer.
 
 Used when the cause of failure is the operator's approval.
 
-- MUST be thrown when operator `isApprovedForAll(owner, operator, id)` is false.
+- MUST be used when operator `isApprovedForAll(owner, operator, id)` is false.
 
 ### Error additions
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -47,7 +47,7 @@ Indicates a failure with the token sender.
 
 - `address sender`: The address of whose tokens are transferred from.
 
-Throw when the cause of failure is the sender in a transfer.
+Used when the cause of failure is the sender in a transfer.
 
 - MUST NOT be thrown for approval operations.
 - MUST NOT be thrown for balance or allowance requirements.
@@ -62,7 +62,7 @@ Indicates a failure with the token receiver.
 
 - `address receiver` The address of whose tokens are transferred to.
 
-Throw when the cause of failure is the receiver in a transfer.
+Used when the cause of failure is the receiver in a transfer.
 
 - MUST NOT be thrown for approval operations.
 - MUST be thrown for unintended transfers to the zero address.
@@ -78,7 +78,7 @@ Indicates an error related to the current `balance` of a sender in a transfer.
 - `uint256 balance`: The current amount of token the sender has.
 - `uint256 needed`: The amount of token the sender needs to perform the operation.
 
-Throw when the cause of failure is the balance of a sender.
+Used when the cause of failure is the balance of a sender.
 
 - MUST NOT be thrown if `balance` is equal or greater than `needed`.
 - MUST be thrown when `balance` is less than `needed`.
@@ -91,7 +91,7 @@ Indicates a failure with the `approver` of a token to be approved.
 
 - `address approver`: The owner's of the tokens to be approved.
 
-Throw when the cause of failure is the owner of the tokens to be approved.
+Used when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
@@ -104,7 +104,7 @@ Indicates a failure with the `spender` to be approved.
 
 - `address spender` The address of who's getting owner's approval.
 
-Throw when the cause of failure is the spender to be approved.
+Used when the cause of failure is the spender to be approved.
 
 - MUST NOT be thrown for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
@@ -121,7 +121,7 @@ Indicates a failure with the `spender`'s `allowance` in a transfer.
 - `uint256 allowance`: The current amount of tokens a spender can use.
 - `uint256 needed`: The allowance needed to perform the operation.
 
-Throw when the cause of failure is the spender's allowance.
+Used when the cause of failure is the spender's allowance.
 
 - MUST NOT be thrown if `allowance` is equal or greater than `needed`.
 - MUST be thrown when `allowance` is less than `needed`.
@@ -136,7 +136,7 @@ Indicates a failure with the token sender.
 
 - `address sender`: The address of whose token is transferred from.
 
-Throw when the cause of failure is the sender in a transfer.
+Used when the cause of failure is the sender in a transfer.
 
 - MUST NOT be thrown for approval operations.
 - MUST NOT be thrown for ownership or approval requirements.
@@ -151,7 +151,7 @@ Indicates a failure with the token receiver.
 
 - `address receiver`: The address of whose token is transferred to.
 
-Throw when the cause of failure is the receiver in a transfer.
+Used when the cause of failure is the receiver in a transfer.
 
 - MUST NOT be thrown for approval operations.
 - MUST be thrown for unintended transfers to the zero address.
@@ -166,7 +166,7 @@ Indicates an error related to the ownership over a particular token.
 
 ##### Parameters
 
-Throw when the cause of failure is the ownership of a token.
+Used when the cause of failure is the ownership of a token.
 
 - MUST NOT be thrown for approval operations.
 - MUST be thrown when `ownerOf(tokenId)` is not `sender`.
@@ -179,7 +179,7 @@ Indicates a failure with the `owner` of a token to be approved.
 
 - `address approver`: The owner's of the token to be approved.
 
-Throw when the cause of failure is the owner of the tokens to be approved.
+Used when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
@@ -192,7 +192,7 @@ Indicates a failure with the `operator` to be approved.
 
 - `address operator`: The address of who's getting owner's approval.
 
-Throw when the cause of failure is the spender to be approved.
+Used when the cause of failure is the spender to be approved.
 
 - MUST NOT be thrown for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
@@ -208,7 +208,7 @@ Indicates a failure with the `operator`'s approval in a transfer.
 - `address operator`: The address of who's transferring a token.
 - `uint256 tokenId`: The token to be transferred.
 
-Throw when the cause of failure is the operator's approval.
+Used when the cause of failure is the operator's approval.
 
 - MUST be thrown when operator `isApprovedForAll(owner, operator)` is false.
 - MUST be thrown when operator `getApproved(tokenId)` is not `operator`.
@@ -223,7 +223,7 @@ Indicates a failure with the token sender.
 
 - `address sender`: The address of whose tokens are transferred from.
 
-Throw when the cause of failure is the sender in a transfer.
+Used when the cause of failure is the sender in a transfer.
 
 - MUST NOT be thrown for approval operations.
 - MUST NOT be thrown for balance or allowance requirements.
@@ -238,7 +238,7 @@ Indicates a failure with the token receiver.
 
 - `address receiver` The address of whose tokens are transferred to.
 
-Throw when the cause of failure is the receiver in a transfer.
+Used when the cause of failure is the receiver in a transfer.
 
 - MUST NOT be thrown for approval operations.
 - MUST be thrown for unintended transfers to the zero address.
@@ -255,7 +255,7 @@ Indicates an error related to the current `balance` of a sender in a transfer.
 - `uint256 needed`: The amount of token the sender needs to perform the operation.
 - `uint256 id`: The id of the token.
 
-Throw when the cause of failure is the balance of a sender.
+Used when the cause of failure is the balance of a sender.
 
 - MUST NOT be thrown if `balance` is equal or greater than `needed` for an `id`.
 - MUST be thrown when `balance` is less than `needed` for an `id`.
@@ -268,7 +268,7 @@ Indicates a failure with the `approver` of a token to be approved.
 
 - `address approver`: The owner's of the tokens to be approved.
 
-Throw when the cause of failure is the owner of the tokens to be approved.
+Used when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
 - MUST be thrown for unintended approvals from the zero address.
@@ -281,7 +281,7 @@ Indicates a failure with the `operator` to be approved.
 
 - `address operator`: The address of who's getting owner's approval.
 
-Throw when the cause of failure is the spender to be approved.
+Used when the cause of failure is the spender to be approved.
 
 - MUST NOT be thrown for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
@@ -297,7 +297,7 @@ Indicates a failure with the `operator`'s approval in a transfer.
 - `address operator`: The address of who's transferring a token.
 - `uint256 id`: The token to be transferred.
 
-Throw when the cause of failure is the operator's approval.
+Used when the cause of failure is the operator's approval.
 
 - MUST be thrown when operator `isApprovedForAll(owner, operator, id)` is false.
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -276,7 +276,7 @@ ERC721InsufficientApproval(address operator, uint256 tokenId);
 
 The selection of arguments depends on the subject involved, and it should follow the order presented below:
 
-1. _Who_ is involved with the error (an `address sender`)
+1. _Who_ is involved with the error (eg. `address sender`)
 2. _What_ failed (eg. `uint256 allowance`)
 3. _Why_ it failed, expressed in additional arguments (eg. `uint256 needed`)
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -13,7 +13,7 @@ created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 
 ## Abstract
 
-The following specification allows for the use of a standard list of Solidity custom errors to be used by [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens.
+This EIP defines a standard set of Solidity custom errors to be used by [EIP-20](./eip-20.md), [EIP-721](./eip-721.md), and [EIP-1155](./eip-1155.md) tokens.
 
 Ethereum applications (DApps) and wallets have historically relied on revert reason strings to show the cause of transaction errors to users. More recent Solidity versions offer rich revert reasons that require error-specific decoding. This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -301,6 +301,10 @@ Throw when the cause of failure is the operator's approval.
 
 - MUST be thrown when operator `isApprovedForAll(_owner, _operator, _id)` is false.
 
+### Error additions
+
+Any addition to this EIP is considerred a new proposal, but SHOULD follow the guidelines presented in the [rationale](#rationale) section to keep consistency.
+
 ## Rationale
 
 The objectives of creating a standard for token errors are to provide context about the error, while keeping gramatical sense, and making a moderated use of meaningful arguments.
@@ -312,39 +316,32 @@ Considering the outlined above, the errors are designed based on the standard ac
 The main actions that can be performed within a token are:
 
 - **Transfer**: An operation in which a _sender_ moves any form of _balance_ to a _receiver_.
-- **Approval**: An operation in which an _approver_ grants any form of _approval_ to an _operator_
+- **Approval**: An operation in which an _approver_ grants any form of _approval_ to an _operator_.
 
-Giving the following list of subjects:
-
-- **Sender**
-- **Receiver**
-- **Balance**
-- **Approver**
-- **Operator**
-- **Approval**
-
-These subjects are expected to be exhaustive to represent _what_ can go wrong on a transaction, which can be shown as an error by adding a [failure prefix](#error-prefixes).
+Whose subjects outlined are expected to be exhaustive to represent _what_ can go wrong in a transaction, which can be shown as an error by adding a [failure prefix](#error-prefixes).
 
 Note that `Token` or `TokenID` MUST NOT be a subject for the following reasons:
 
 1. The [Domain](#domain) is explicit enough to identify it as a token error.
 2. Although `TokenID` may identify an error, the token itself SHOULD NOT the root of the error, but can be additional information.
 
+Consider that, in practice, some of the subjects in a contract might be called different while they represent the same. These are listed below:
+
+- **Balance**: Represents the access to a certain amount of tokens for an address.
+  - EIP-721: Instead of _balance_, an address is _owner_ of a token.
+- **Approval**: Represents a permission granted to an operator.
+  - EIP-20: Instead of _approval_, an operator has _allowance_.
+- **Operator**: Represents an address that has received approval over third-party tokens.
+  - EIP-20: Instead of _operator_, an address with allowance is an _spender_.
+
+If a subject is called different on a particular token standard, the error MUST be consistent with the standard's naming convention.
+
 ### Error prefixes
 
-- **Invalid**: Used for general incorrectness.
-- **Insufficient**: Used when defining an error for amounts (eg. balance, approval).
+An error prefix is what complements a subject, so it can be read as an error.
+Developers can think about an error prefix as the _why_ an error happened.
 
-These prefixes combined with the subjects create the following list of base standard errors.
-
-### Base standard errors
-
-- **InvalidSender**
-- **InvalidReceiver**
-- **InsufficientBalance**
-- **InvalidApprover**
-- **InvalidOperator**
-- **InsufficientApproval**
+A prefix can be `Invalid` for general incorrectness, or more specific like `Insufficient` for amounts (or lack of).
 
 ### Domain
 
@@ -366,19 +363,6 @@ ERC20InsufficientApproval(address _spender, uint256 _allowance, uint256 _needed)
 ERC721InsufficientApproval(address _operator, uint256 _tokenId);
 ```
 
-### Subject naming adjustments
-
-While the base standard errors can work with the current standard token implementations, in practice, some of the subjects in a contract might be called different while they represent the same. These are listed below:
-
-- **Balance**: Represents the access to a certain amount of tokens for an address.
-  - EIP-721: Instead of _balance_, an address is _owner_ of a token.
-- **Approval**: Represents a permission granted to an operator.
-  - EIP-20: Instead of _approval_, an operator has _allowance_.
-- **Operator**: Represents an address that has received approval over third-party tokens.
-  - EIP-20: Instead of _operator_, an address with allowance is an _spender_.
-
-If a subject is called different on a particular token standard, the error MUST be consistent with the standard's naming convention.
-
 ### Arguments
 
 The selection of arguments depends on the subject involved, and it MUST follow the order presented below:
@@ -389,7 +373,7 @@ The selection of arguments depends on the subject involved, and it MUST follow t
 
 Consider that sometimes _Who_ is also the _What_, that's why argument 2 is also optional.
 
-Note: Some tokens may need a `_tokenId` or `_id`. This is suggested to include at the end as additional information, according to the [subjects list](#actions-and-subjects)
+Note: Some tokens may need a `_tokenId` or `_id`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
 
 ### Error grammar rules
 
@@ -402,8 +386,8 @@ Given the above, we can summarize the construction of error names with a grammar
 Where:
 
 - _Domain_: SHOULD be `ERC20`, `ERC721` or `ERC1155`. Although other token standards may be suggested if not considered in this EIP.
-- _ErrorPrefix_: MUST be `Invalid` or `Insufficient`.
-- _Actor_: SHOULD be `Sender`, `Receiver`, `Balance`, `Approver`, `Operator` or `Approval`, and MUST make adjustments based on domain's naming convention.
+- _ErrorPrefix_: MAY be `Invalid`, `Insufficient`, or another if it's more appropiated.
+- _Actor_: MAY be `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropiated, and MUST make adjustments based on domain's naming convention.
 - _Arguments_: MUST follow the [_who_, _what_ and _why_ order](#arguments).
 
 ## Backwards Compatibility

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -212,7 +212,7 @@ Used in batch transfers.
 | ----------- | ----------------------------------------------------------------------------------- |
 | `sender`    | Address whose tokens are being transferred.                                         |
 | `balance`   | Current balance for the interacting account.                                        |
-| `needed`    | Amount minimum required to perform an action.                                       |
+| `needed`    | Minimum amount required to perform an action.                                       |
 | `receiver`  | Address owner of the token(s) transferred.                                          |
 | `spender`   | Address not owner of the token(s) transferred, but allowed to operate on (it/them). |
 | `allowance` | Amount of token(s) a `spender` is allowed to operate with.                          |

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -213,7 +213,7 @@ Used in batch transfers.
 | `sender`    | Address whose tokens are being transferred.                                         |
 | `balance`   | Current balance for the interacting account.                                        |
 | `needed`    | Minimum amount required to perform an action.                                       |
-| `receiver`  | Address owner of the token(s) transferred.                                          |
+| `receiver`  | Address to which tokens are being transferred.                                      |
 | `spender`   | Address that may be allowed to operate on tokens without being their owner.         |
 | `allowance` | Amount of tokens a `spender` is allowed to operate with.                            |
 | `approver`  | Owner of the token(s) being approved to an `spender`.                               |

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -52,7 +52,7 @@ Used when the cause of failure is the sender in a transfer.
 - MUST NOT be thrown for approval operations.
 - MUST NOT be thrown for balance or allowance requirements.
   - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
-- MUST be thrown for unintended transfers from the zero address.
+- MUST be thrown for disallowed transfers from the zero address.
 
 #### `ERC20InvalidReceiver(address)`
 
@@ -65,8 +65,8 @@ Indicates a failure with the token receiver.
 Used when the cause of failure is the receiver in a transfer.
 
 - MUST NOT be thrown for approval operations.
-- MUST be thrown for unintended transfers to the zero address.
-- MUST be thrown for unintended transfers to non-compatible addresses (eg. contract addresses).
+- MUST be thrown for disallowed transfers to the zero address.
+- MUST be thrown for disallowed transfers to non-compatible addresses (eg. contract addresses).
 
 #### `ERC20InsufficientBalance(address, uint256, uint256)`
 
@@ -94,7 +94,7 @@ Indicates a failure with the `approver` of a token to be approved.
 Used when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
-- MUST be thrown for unintended approvals from the zero address.
+- MUST be thrown for disallowed approvals from the zero address.
 
 #### `ERC20InvalidSpender(address)`
 
@@ -108,8 +108,8 @@ Used when the cause of failure is the spender to be approved.
 
 - MUST NOT be thrown for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
-- MUST be thrown for unintended approvals to the zero address.
-- MUST be thrown for unintended approvals to the owner itself.
+- MUST be thrown for disallowed approvals to the zero address.
+- MUST be thrown for disallowed approvals to the owner itself.
 
 #### `ERC20InsufficientAllowance(address, uint256, uint256)`
 
@@ -141,7 +141,7 @@ Used when the cause of failure is the sender in a transfer.
 - MUST NOT be thrown for approval operations.
 - MUST NOT be thrown for ownership or approval requirements.
   - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
-- MUST be thrown for unintended transfers from the zero address.
+- MUST be thrown for disallowed transfers from the zero address.
 
 #### `ERC721InvalidReceiver(address)`
 
@@ -154,8 +154,8 @@ Indicates a failure with the token receiver.
 Used when the cause of failure is the receiver in a transfer.
 
 - MUST NOT be thrown for approval operations.
-- MUST be thrown for unintended transfers to the zero address.
-- MUST be thrown for unintended transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
+- MUST be thrown for disallowed transfers to the zero address.
+- MUST be thrown for disallowed transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
 
 #### `ERC721InvalidOwner(address, uint256)`
 
@@ -182,7 +182,7 @@ Indicates a failure with the `owner` of a token to be approved.
 Used when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
-- MUST be thrown for unintended approvals from the zero address.
+- MUST be thrown for disallowed approvals from the zero address.
 
 #### `ERC721InvalidOperator(address)`
 
@@ -196,8 +196,8 @@ Used when the cause of failure is the spender to be approved.
 
 - MUST NOT be thrown for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
-- MUST be thrown for unintended approvals to the zero address.
-- MUST be thrown for unintended approvals to the owner itself.
+- MUST be thrown for disallowed approvals to the zero address.
+- MUST be thrown for disallowed approvals to the owner itself.
 
 #### `ERC721InsufficientApproval(address, uint256)`
 
@@ -228,7 +228,7 @@ Used when the cause of failure is the sender in a transfer.
 - MUST NOT be thrown for approval operations.
 - MUST NOT be thrown for balance or allowance requirements.
   - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
-- MUST be thrown for unintended transfers from the zero address.
+- MUST be thrown for disallowed transfers from the zero address.
 
 #### `ERC1155InvalidReceiver(address)`
 
@@ -241,8 +241,8 @@ Indicates a failure with the token receiver.
 Used when the cause of failure is the receiver in a transfer.
 
 - MUST NOT be thrown for approval operations.
-- MUST be thrown for unintended transfers to the zero address.
-- MUST be thrown for unintended transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
+- MUST be thrown for disallowed transfers to the zero address.
+- MUST be thrown for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 
 #### `ERC1155InsufficientBalance(address, uint256, uint256, uint256)`
 
@@ -271,7 +271,7 @@ Indicates a failure with the `approver` of a token to be approved.
 Used when the cause of failure is the owner of the tokens to be approved.
 
 - MUST NOT be thrown for transfer operations.
-- MUST be thrown for unintended approvals from the zero address.
+- MUST be thrown for disallowed approvals from the zero address.
 
 #### `ERC1155InvalidOperator(address)`
 
@@ -285,8 +285,8 @@ Used when the cause of failure is the spender to be approved.
 
 - MUST NOT be thrown for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
-- MUST be thrown for unintended approvals to the zero address.
-- MUST be thrown for unintended approvals to the owner itself.
+- MUST be thrown for disallowed approvals to the zero address.
+- MUST be thrown for disallowed approvals to the owner itself.
 
 #### `ERC1155InsufficientApproval(address, uint256)`
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -282,7 +282,7 @@ The selection of arguments depends on the subject involved, and it should follow
 
 A particular argument may fall in overlapping categories (eg. _Who_ may also be _What_), so not all of these will be present but the order shouldn't be broken.
 
-Note: Some tokens may need a `tokenId`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
+Some tokens may need a `tokenId`. This is suggested to include at the end as additional information instead of as a subject.
 
 ### Error grammar rules
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -33,9 +33,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 The provided interfaces with errors SHOULD conform with the [error grammar rules](#error-grammar-rules) described in the [rationale](#rationale) section.
 
-It's important to note that errors MAY be used in each scenario, but that's up to the implementers, unless a revert reason is specified in their corresponding EIPs.
-
-This EIP aims to provide a clear standard only in case an error will be used.
+This EIP defines standard errors that may be used by implementations in certain scenarios, but does not specify whether implementations should revert in those scenarios, which remains up to the implementers, unless a revert is mandated by the corresponding EIPs.
 
 ### [EIP-20](./eip-20.md)
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -210,7 +210,7 @@ Used in batch transfers.
 
 | Name        | Description                                                                         |
 | ----------- | ----------------------------------------------------------------------------------- |
-| `sender`    | The address of whose token(s) (is/are) transferred from.                            |
+| `sender`    | Address whose tokens are being transferred.                                         |
 | `balance`   | Current balance for the interacting account.                                        |
 | `needed`    | Amount minimum required to perform an action.                                       |
 | `receiver`  | Address owner of the token(s) transferred.                                          |

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -33,7 +33,7 @@ The following errors were designed according to the criteria described in [Ratio
 
 This EIP defines standard errors that may be used by implementations in certain scenarios, but does not specify whether implementations should revert in those scenarios, which remains up to the implementers, unless a revert is mandated by the corresponding EIPs.
 
-The names of the error arguments follow the [parameter glossary](#parameter-glossary) section, defining a clear guideline for assigning values to them.
+The names of the error arguments are defined in the [Parameter Glossary](#parameter-glossary), and MUST be used according to those definitions.
 
 ### [EIP-20](./eip-20.md)
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -147,13 +147,13 @@ Used in approvals.
 
 ### [EIP-1155](./eip-1155.md)
 
-#### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id)`
+#### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId)`
 
 Indicates an error related to the current `balance` of a sender.
 Used in transfers.
 
-- MUST be used when `balance` is less than `needed` for an `id`.
-- MUST NOT be used if `balance` is equal or greater than `needed` for an `id`.
+- MUST be used when `balance` is less than `needed` for a `tokenId`.
+- MUST NOT be used if `balance` is equal or greater than `needed` for an `tokenId`.
 
 #### `ERC1155InvalidSender(address sender)`
 
@@ -174,12 +174,12 @@ Used in transfers.
 - MUST be used for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 - MUST NOT be used for approval operations.
 
-#### `ERC1155InsufficientApproval(address operator, uint256 id)`
+#### `ERC1155InsufficientApproval(address operator, uint256 tokenId)`
 
 Indicates a failure with the `operator`'s approval in a transfer.
 Used in transfers.
 
-- MUST be used when operator `isApprovedForAll(owner, operator, id)` is false.
+- MUST be used when operator `isApprovedForAll(owner, operator, tokenId)` is false.
 
 #### `ERC1155InvalidApprover(address approver)`
 
@@ -217,10 +217,9 @@ Used in batch transfers.
 | `spender`   | Address that may be allowed to operate on tokens without being their owner. |
 | `allowance` | Amount of tokens a `spender` is allowed to operate with.                    |
 | `approver`  | Address initiating an approval operation.                                   |
-| `tokenId`   | The identifier number of a token type.                                      |
-| `owner`     | Address of the owner of a token type.                                       |
+| `tokenId`   | The identifier number of a token.                                           |
+| `owner`     | Address of the owner of a token.                                            |
 | `operator`  | Same as `spender`.                                                          |
-| `id`        | Same as `tokenId`.                                                          |
 | `*Length`   | Array length for the prefixed parameter.                                    |
 
 ### Error additions
@@ -244,21 +243,9 @@ The main actions that can be performed within a token are:
 
 The subjects outlined above are expected to exhaustively represent _what_ can go wrong in a token transaction, deriving a specific error by adding an [error prefix](#error-prefixes).
 
-Note that `Token` or `TokenID` MUST NOT be a subject for the following reasons:
+Note that the action is never seen as the subject of an error. Additionally the token itself is not seen as the subject of an error but rather the context in which it happens, as identified in the domain.
 
-1. The [Domain](#domain) is explicit enough to identify it as a token error.
-2. Although `TokenID` may identify an error, the token itself SHOULD NOT the root of the error, but can be additional information.
-
-Consider that, in practice, some of the subjects in a contract might be called different while they represent the same. These are listed below:
-
-- **Balance**: Represents the access to a certain amount of tokens for an address.
-  - EIP-721: Instead of _balance_, an address is _owner_ of a token.
-- **Approval**: Represents a permission granted to an operator.
-  - EIP-20: Instead of _approval_, an operator has _allowance_.
-- **Operator**: Represents an address that has received approval over third-party tokens.
-  - EIP-20: Instead of _operator_, an address with allowance is an _spender_.
-
-If a subject is called different on a particular token standard, the error MUST be consistent with the standard's naming convention.
+If a subject is called different on a particular token standard, the error should be consistent with the standard's naming convention.
 
 ### Error prefixes
 
@@ -289,19 +276,19 @@ ERC721InsufficientApproval(address operator, uint256 tokenId);
 
 ### Arguments
 
-The selection of arguments depends on the subject involved, and it SHOULD follow the order presented below:
+The selection of arguments depends on the subject involved, and it should follow the order presented below:
 
 1. _Who_ is involved with the error (an `address sender`)
 2. _What_ failed (eg. `uint256 allowance`)
 3. _Why_ it failed, expressed in additional arguments (eg. `uint256 needed`)
 
-A particular argument may fall in overlapping categories (eg. _Who_ may also be _What_), so not all of these will be present but the order SHOULD NOT be broken.
+A particular argument may fall in overlapping categories (eg. _Who_ may also be _What_), so not all of these will be present but the order shouldn't be broken.
 
-Note: Some tokens may need a `tokenId` or `id`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
+Note: Some tokens may need a `tokenId`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
 
 ### Error grammar rules
 
-Given the above, we can summarize the construction of error names with a grammar that errors MUST follow:
+Given the above, we can summarize the construction of error names with a grammar that errors will follow:
 
 ```
 <Domain><ErrorPrefix><Subject>(<Arguments>);
@@ -309,10 +296,10 @@ Given the above, we can summarize the construction of error names with a grammar
 
 Where:
 
-- _Domain_: SHOULD be `ERC20`, `ERC721` or `ERC1155`. Although other token standards may be suggested if not considered in this EIP.
-- _ErrorPrefix_: MAY be `Invalid`, `Insufficient`, or another if it's more appropiated.
-- _Subject_: MAY be `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropiated, and MUST make adjustments based on domain's naming convention.
-- _Arguments_: MUST follow the [_who_, _what_ and _why_ order](#arguments).
+- _Domain_: `ERC20`, `ERC721` or `ERC1155`. Although other token standards may be suggested if not considered in this EIP.
+- _ErrorPrefix_: `Invalid`, `Insufficient`, or another if it's more appropiated.
+- _Subject_: `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropiated, and must make adjustments based on domain's naming convention.
+- _Arguments_: Follow the [_who_, _what_ and _why_ order](#arguments).
 
 ## Backwards Compatibility
 
@@ -364,10 +351,10 @@ interface ERC721Errors {
 /// @dev See https://eips.ethereum.org/EIPS/eip-1155
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC1155Errors {
-    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id);
+    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);
     error ERC1155InvalidSender(address sender);
     error ERC1155InvalidReceiver(address receiver);
-    error ERC1155InsufficientApproval(address operator, uint256 id);
+    error ERC1155InsufficientApproval(address operator, uint256 tokenId);
     error ERC1155InvalidApprover(address approver);
     error ERC1155InvalidOperator(address operator);
     error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -287,8 +287,6 @@ ERC20InsufficientApproval(address spender, uint256 allowance, uint256 needed);
 ERC721InsufficientApproval(address operator, uint256 tokenId);
 ```
 
-A prefix is also RECOMMENDED for cases when there's
-
 ### Arguments
 
 The selection of arguments depends on the subject involved, and it SHOULD follow the order presented below:

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -37,7 +37,7 @@ This EIP defines standard errors that may be used by implementations in certain 
 
 ### [EIP-20](./eip-20.md)
 
-#### `ERC20InvalidSender(address)`
+#### `ERC20InvalidSender(address sender)`
 
 Indicates a failure with the token sender.
 
@@ -52,7 +52,7 @@ Used when the cause of failure is the sender in a transfer.
 - MUST NOT be used for balance or allowance requirements.
   - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
 
-#### `ERC20InvalidReceiver(address)`
+#### `ERC20InvalidReceiver(address receiver)`
 
 Indicates a failure with the token receiver.
 
@@ -66,7 +66,7 @@ Used when the cause of failure is the receiver in a transfer.
 - MUST be used for disallowed transfers to non-compatible addresses (eg. contract addresses).
 - MUST NOT be used for approval operations.
 
-#### `ERC20InsufficientBalance(address, uint256, uint256)`
+#### `ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)`
 
 Indicates an error related to the current `balance` of a sender in a transfer.
 
@@ -81,7 +81,7 @@ Used when the cause of failure is the balance of a sender.
 - MUST be used when `balance` is less than `needed`.
 - MUST NOT be used if `balance` is equal or greater than `needed`.
 
-#### `ERC20InvalidApprover(address)`
+#### `ERC20InvalidApprover(address approver)`
 
 Indicates a failure with the `approver` of a token to be approved.
 
@@ -94,7 +94,7 @@ Used when the cause of failure is the owner of the tokens to be approved.
 - MUST be used for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
 
-#### `ERC20InvalidSpender(address)`
+#### `ERC20InvalidSpender(address spender)`
 
 Indicates a failure with the `spender` to be approved.
 
@@ -109,7 +109,7 @@ Used when the cause of failure is the spender to be approved.
 - MUST NOT be used for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
 
-#### `ERC20InsufficientAllowance(address, uint256, uint256)`
+#### `ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)`
 
 Indicates a failure with the `spender`'s `allowance` in a transfer.
 
@@ -126,7 +126,7 @@ Used when the cause of failure is the spender's allowance.
 
 ### [EIP-721](./eip-721.md)
 
-#### `ERC721InvalidSender(address)`
+#### `ERC721InvalidSender(address sender)`
 
 Indicates a failure with the token sender.
 
@@ -141,7 +141,7 @@ Used when the cause of failure is the sender in a transfer.
 - MUST NOT be used for ownership or approval requirements.
   - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
 
-#### `ERC721InvalidReceiver(address)`
+#### `ERC721InvalidReceiver(address receiver)`
 
 Indicates a failure with the token receiver.
 
@@ -155,7 +155,7 @@ Used when the cause of failure is the receiver in a transfer.
 - MUST be used for disallowed transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
 - MUST NOT be used for approval operations.
 
-#### `ERC721InvalidOwner(address, uint256)`
+#### `ERC721InvalidOwner(address sender, uint256 tokenId)`
 
 Indicates an error related to the ownership over a particular token.
 
@@ -169,7 +169,7 @@ Used when the cause of failure is the ownership of a token.
 - MUST be used when `ownerOf(tokenId)` is not `sender`.
 - MUST NOT be used for approval operations.
 
-#### `ERC721InvalidApprover(address)`
+#### `ERC721InvalidApprover(address approver)`
 
 Indicates a failure with the `owner` of a token to be approved.
 
@@ -182,7 +182,7 @@ Used when the cause of failure is the owner of the tokens to be approved.
 - MUST be used for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
 
-#### `ERC721InvalidOperator(address)`
+#### `ERC721InvalidOperator(address operator)`
 
 Indicates a failure with the `operator` to be approved.
 
@@ -197,7 +197,7 @@ Used when the cause of failure is the spender to be approved.
 - MUST NOT be used for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
 
-#### `ERC721InsufficientApproval(address, uint256)`
+#### `ERC721InsufficientApproval(address operator, uint256 tokenId)`
 
 Indicates a failure with the `operator`'s approval in a transfer.
 
@@ -213,7 +213,7 @@ Used when the cause of failure is the operator's approval.
 
 ### [EIP-1155](./eip-1155.md)
 
-#### `ERC1155InvalidSender(address)`
+#### `ERC1155InvalidSender(address sender)`
 
 Indicates a failure with the token sender.
 
@@ -228,7 +228,7 @@ Used when the cause of failure is the sender in a transfer.
 - MUST NOT be used for balance or allowance requirements.
   - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
 
-#### `ERC1155InvalidReceiver(address)`
+#### `ERC1155InvalidReceiver(address receiver)`
 
 Indicates a failure with the token receiver.
 
@@ -242,7 +242,7 @@ Used when the cause of failure is the receiver in a transfer.
 - MUST be used for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 - MUST NOT be used for approval operations.
 
-#### `ERC1155InsufficientBalance(address, uint256, uint256, uint256)`
+#### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id)`
 
 Indicates an error related to the current `balance` of a sender in a transfer.
 
@@ -258,7 +258,7 @@ Used when the cause of failure is the balance of a sender.
 - MUST be used when `balance` is less than `needed` for an `id`.
 - MUST NOT be used if `balance` is equal or greater than `needed` for an `id`.
 
-#### `ERC1155InvalidApprover(address)`
+#### `ERC1155InvalidApprover(address approver)`
 
 Indicates a failure with the `approver` of a token to be approved.
 
@@ -271,7 +271,7 @@ Used when the cause of failure is the owner of the tokens to be approved.
 - MUST be used for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
 
-#### `ERC1155InvalidOperator(address)`
+#### `ERC1155InvalidOperator(address operator)`
 
 Indicates a failure with the `operator` to be approved.
 
@@ -286,7 +286,7 @@ Used when the cause of failure is the spender to be approved.
 - MUST NOT be used for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
 
-#### `ERC1155InsufficientApproval(address, uint256)`
+#### `ERC1155InsufficientApproval(address operator, uint256 id)`
 
 Indicates a failure with the `operator`'s approval in a transfer.
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -329,7 +329,7 @@ This EIP can not be enforced on non-upgradeable already deployed tokens, however
 
 Upgradeable contracts MAY be upgraded to implement this EIP.
 
-Implementers and DApp developers SHOULD expect these EIP errors to be present on new deployed contracts, but SHOULD handle variation errors for existing contracts, and revert strings that may be returned.
+Implementers and DApp developers that implement special support for tokens that are compliant with this EIP, SHOULD tolerate different errors emitted by non-compliant contracts, as well as classic revert strings.
 
 ## Reference Implementation
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -201,7 +201,7 @@ Used in approvals.
 
 #### `ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength)`
 
-Indicates an array length mismatch between `_ids` and `_values` in a `safeBatchTransferFrom` operation.
+Indicates an array length mismatch between `ids` and `values` in a `safeBatchTransferFrom` operation.
 Used in batch transfers.
 
 - MUST be used only if `idsLength` is different to `valuesLength`

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -231,9 +231,9 @@ Implementation specific errors (such as extensions) SHOULD also follow the same 
 
 ## Rationale
 
-The objectives of creating a standard for token errors are to provide context about the error, while keeping gramatical sense, and making a moderated use of meaningful arguments.
+The chosen objectives for a standard for token errors are to provide context about the error, and to make moderate use of meaningful arguments (to maintain the code size benefits with respect to strings).
 
-Considering the outlined above, the errors are designed based on the standard actions that can be performed on each token, and the [subjects](#actions-and-subjects) involved.
+Considering this, the error names are designed following a basic grammatical structure based on the standard actions that can be performed on each token and the [subjects](#actions-and-subjects) involved.
 
 ### Actions and subjects
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -215,7 +215,7 @@ Used in batch transfers.
 | `needed`    | Minimum amount required to perform an action.                                       |
 | `receiver`  | Address owner of the token(s) transferred.                                          |
 | `spender`   | Address that may be allowed to operate on tokens without being their owner.         |
-| `allowance` | Amount of token(s) a `spender` is allowed to operate with.                          |
+| `allowance` | Amount of tokens a `spender` is allowed to operate with.                            |
 | `approver`  | Owner of the token(s) being approved to an `spender`.                               |
 | `tokenId`   | The identifier number of a token type.                                              |
 | `owner`     | Address of the owner of a token type.                                               |

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -37,6 +37,21 @@ This EIP defines standard errors that may be used by implementations in certain 
 
 ### [EIP-20](./eip-20.md)
 
+#### `ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)`
+
+Indicates an error related to the current `balance` of a sender in a transfer.
+
+##### Parameters
+
+- `address sender`: The address of whose tokens are transferred from.
+- `uint256 balance`: The current amount of token the sender has.
+- `uint256 needed`: The amount of token the sender needs to perform the operation.
+
+Used when the cause of failure is the balance of a sender.
+
+- MUST be used when `balance` is less than `needed`.
+- MUST NOT be used if `balance` is equal or greater than `needed`.
+
 #### `ERC20InvalidSender(address sender)`
 
 Indicates a failure with the token sender.
@@ -66,20 +81,20 @@ Used when the cause of failure is the receiver in a transfer.
 - MUST be used for disallowed transfers to non-compatible addresses (eg. contract addresses).
 - MUST NOT be used for approval operations.
 
-#### `ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)`
+#### `ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)`
 
-Indicates an error related to the current `balance` of a sender in a transfer.
+Indicates a failure with the `spender`'s `allowance` in a transfer.
 
 ##### Parameters
 
-- `address sender`: The address of whose tokens are transferred from.
-- `uint256 balance`: The current amount of token the sender has.
-- `uint256 needed`: The amount of token the sender needs to perform the operation.
+- `address spender`: The address of who's spending the tokens.
+- `uint256 allowance`: The current amount of tokens a spender can use.
+- `uint256 needed`: The allowance needed to perform the operation.
 
-Used when the cause of failure is the balance of a sender.
+Used when the cause of failure is the spender's allowance.
 
-- MUST be used when `balance` is less than `needed`.
-- MUST NOT be used if `balance` is equal or greater than `needed`.
+- MUST be used when `allowance` is less than `needed`.
+- MUST NOT be used if `allowance` is equal or greater than `needed`.
 
 #### `ERC20InvalidApprover(address approver)`
 
@@ -109,22 +124,21 @@ Used when the cause of failure is the spender to be approved.
 - MUST NOT be used for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
 
-#### `ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)`
+### [EIP-721](./eip-721.md)
 
-Indicates a failure with the `spender`'s `allowance` in a transfer.
+#### `ERC721InvalidOwner(address sender, uint256 tokenId)`
+
+Indicates an error related to the ownership over a particular token.
 
 ##### Parameters
 
-- `address spender`: The address of who's spending the tokens.
-- `uint256 allowance`: The current amount of tokens a spender can use.
-- `uint256 needed`: The allowance needed to perform the operation.
+- `address sender`: The address of whose token is transferred from.
+- `uint256 tokenId`: The id of the token to be transferred.
 
-Used when the cause of failure is the spender's allowance.
+Used when the cause of failure is the ownership of a token.
 
-- MUST be used when `allowance` is less than `needed`.
-- MUST NOT be used if `allowance` is equal or greater than `needed`.
-
-### [EIP-721](./eip-721.md)
+- MUST be used when `ownerOf(tokenId)` is not `sender`.
+- MUST NOT be used for approval operations.
 
 #### `ERC721InvalidSender(address sender)`
 
@@ -155,19 +169,19 @@ Used when the cause of failure is the receiver in a transfer.
 - MUST be used for disallowed transfers to non-ERC721TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
 - MUST NOT be used for approval operations.
 
-#### `ERC721InvalidOwner(address sender, uint256 tokenId)`
+#### `ERC721InsufficientApproval(address operator, uint256 tokenId)`
 
-Indicates an error related to the ownership over a particular token.
-
-- `address sender`: The address of whose token is transferred from.
-- `uint256 tokenId`: The id of the token to be transferred.
+Indicates a failure with the `operator`'s approval in a transfer.
 
 ##### Parameters
 
-Used when the cause of failure is the ownership of a token.
+- `address operator`: The address of who's transferring a token.
+- `uint256 tokenId`: The token to be transferred.
 
-- MUST be used when `ownerOf(tokenId)` is not `sender`.
-- MUST NOT be used for approval operations.
+Used when the cause of failure is the operator's approval.
+
+- MUST be used when operator `isApprovedForAll(owner, operator)` is false.
+- MUST be used when operator `getApproved(tokenId)` is not `operator`.
 
 #### `ERC721InvalidApprover(address approver)`
 
@@ -197,21 +211,23 @@ Used when the cause of failure is the spender to be approved.
 - MUST NOT be used for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
 
-#### `ERC721InsufficientApproval(address operator, uint256 tokenId)`
+### [EIP-1155](./eip-1155.md)
 
-Indicates a failure with the `operator`'s approval in a transfer.
+#### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id)`
+
+Indicates an error related to the current `balance` of a sender in a transfer.
 
 ##### Parameters
 
-- `address operator`: The address of who's transferring a token.
-- `uint256 tokenId`: The token to be transferred.
+- `address sender`: The address of whose tokens are transferred from.
+- `uint256 balance`: The current amount of token the sender has.
+- `uint256 needed`: The amount of token the sender needs to perform the operation.
+- `uint256 id`: The id of the token.
 
-Used when the cause of failure is the operator's approval.
+Used when the cause of failure is the balance of a sender.
 
-- MUST be used when operator `isApprovedForAll(owner, operator)` is false.
-- MUST be used when operator `getApproved(tokenId)` is not `operator`.
-
-### [EIP-1155](./eip-1155.md)
+- MUST be used when `balance` is less than `needed` for an `id`.
+- MUST NOT be used if `balance` is equal or greater than `needed` for an `id`.
 
 #### `ERC1155InvalidSender(address sender)`
 
@@ -242,21 +258,18 @@ Used when the cause of failure is the receiver in a transfer.
 - MUST be used for disallowed transfers to non-ERC1155TokenReceiver contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 - MUST NOT be used for approval operations.
 
-#### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id)`
+#### `ERC1155InsufficientApproval(address operator, uint256 id)`
 
-Indicates an error related to the current `balance` of a sender in a transfer.
+Indicates a failure with the `operator`'s approval in a transfer.
 
 ##### Parameters
 
-- `address sender`: The address of whose tokens are transferred from.
-- `uint256 balance`: The current amount of token the sender has.
-- `uint256 needed`: The amount of token the sender needs to perform the operation.
-- `uint256 id`: The id of the token.
+- `address operator`: The address of who's transferring a token.
+- `uint256 id`: The token to be transferred.
 
-Used when the cause of failure is the balance of a sender.
+Used when the cause of failure is the operator's approval.
 
-- MUST be used when `balance` is less than `needed` for an `id`.
-- MUST NOT be used if `balance` is equal or greater than `needed` for an `id`.
+- MUST be used when operator `isApprovedForAll(owner, operator, id)` is false.
 
 #### `ERC1155InvalidApprover(address approver)`
 
@@ -285,19 +298,6 @@ Used when the cause of failure is the spender to be approved.
 - MUST be used for disallowed approvals to the owner itself.
 - MUST NOT be used for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
-
-#### `ERC1155InsufficientApproval(address operator, uint256 id)`
-
-Indicates a failure with the `operator`'s approval in a transfer.
-
-##### Parameters
-
-- `address operator`: The address of who's transferring a token.
-- `uint256 id`: The token to be transferred.
-
-Used when the cause of failure is the operator's approval.
-
-- MUST be used when operator `isApprovedForAll(owner, operator, id)` is false.
 
 ### Error additions
 
@@ -418,54 +418,54 @@ pragma solidity ^0.8.4;
 /// @dev See https://eips.ethereum.org/EIPS/eip-20
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC20Errors {
+    /// @notice See [reference](#erc20insufficientbalance).
+    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
     /// @notice See [reference](#erc20invalidsender).
     error ERC20InvalidSender(address sender);
     /// @notice See [reference](#erc20invalidreceiver).
     error ERC20InvalidReceiver(address receiver);
-    /// @notice See [reference](#erc20insufficientbalance).
-    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
+    /// @notice See [reference](#erc20insufficientallowance).
+    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
     /// @notice See [reference](#erc20invalidapprover).
     error ERC20InvalidApprover(address approver);
     /// @notice See [reference](#erc20invalidspender).
     error ERC20InvalidSpender(address spender);
-    /// @notice See [reference](#erc20insufficientallowance).
-    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
 }
 
 /// @title Standard ERC721 Errors
 /// @dev See https://eips.ethereum.org/EIPS/eip-721
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC721Errors {
+    /// @notice See [reference](#erc721invalidowner).
+    error ERC721InvalidOwner(address sender, uint256 tokenId);
     /// @notice See [reference](#erc721invalidsender).
     error ERC721InvalidSender(address sender);
     /// @notice See [reference](#erc721invalidreceiver).
     error ERC721InvalidReceiver(address receiver);
-    /// @notice See [reference](#erc721invalidowner).
-    error ERC721InvalidOwner(address sender, uint256 tokenId);
+    /// @notice See [reference](#erc721insufficientapproval).
+    error ERC721InsufficientApproval(address operator, uint256 tokenId);
     /// @notice See [reference](#erc721invalidapprover).
     error ERC721InvalidApprover(address approver);
     /// @notice See [reference](#erc721invalidoperator).
     error ERC721InvalidOperator(address operator);
-    /// @notice See [reference](#erc721insufficientapproval).
-    error ERC721InsufficientApproval(address operator, uint256 tokenId);
 }
 
 /// @title Standard ERC1155 Errors
 /// @dev See https://eips.ethereum.org/EIPS/eip-1155
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC1155Errors {
+    /// @notice See [reference](#erc1155insufficientbalance).
+    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id);
     /// @notice See [reference](#erc1155invalidsender).
     error ERC1155InvalidSender(address sender);
     /// @notice See [reference](#erc1155invalidreceiver).
     error ERC1155InvalidReceiver(address receiver);
-    /// @notice See [reference](#erc1155insufficientbalance).
-    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id);
+    /// @notice See [reference](#erc1155insufficientapproval).
+    error ERC1155InsufficientApproval(address operator, uint256 id);
     /// @notice See [reference](#erc1155invalidapprover).
     error ERC1155InvalidApprover(address approver);
     /// @notice See [reference](#erc1155invalidoperator).
     error ERC1155InvalidOperator(address operator);
-    /// @notice See [reference](#erc1155insufficientapproval).
-    error ERC1155InsufficientApproval(address operator, uint256 id);
 }
 ```
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -45,7 +45,7 @@ Indicates a failure with the token sender.
 
 ##### Parameters
 
-- `address _sender`: The address of whose tokens are transferred from.
+- `address sender`: The address of whose tokens are transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -60,7 +60,7 @@ Indicates a failure with the token receiver.
 
 ##### Parameters
 
-- `address _receiver` The address of whose tokens are transferred to.
+- `address receiver` The address of whose tokens are transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -70,26 +70,26 @@ Throw when the cause of failure is the receiver in a transfer.
 
 #### `ERC20InsufficientBalance(address, uint256, uint256)`
 
-Indicates an error related to the current `_balance` of a sender in a transfer.
+Indicates an error related to the current `balance` of a sender in a transfer.
 
 ##### Parameters
 
-- `address _sender`: The address of whose tokens are transferred from.
-- `uint256 _balance`: The current amount of token the sender has.
-- `uint256 _needed`: The amount of token the sender needs to perform the operation.
+- `address sender`: The address of whose tokens are transferred from.
+- `uint256 balance`: The current amount of token the sender has.
+- `uint256 needed`: The amount of token the sender needs to perform the operation.
 
 Throw when the cause of failure is the balance of a sender.
 
-- MUST NOT be thrown if `_balance` is equal or greater than `_needed`.
-- MUST be thrown when `_balance` is less than `_needed`.
+- MUST NOT be thrown if `balance` is equal or greater than `needed`.
+- MUST be thrown when `balance` is less than `needed`.
 
 #### `ERC20InvalidApprover(address)`
 
-Indicates a failure with the `_approver` of a token to be approved.
+Indicates a failure with the `approver` of a token to be approved.
 
 ##### Parameters
 
-- `address _approver`: The owner's of the tokens to be approved.
+- `address approver`: The owner's of the tokens to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
@@ -98,11 +98,11 @@ Throw when the cause of failure is the owner of the tokens to be approved.
 
 #### `ERC20InvalidSpender(address)`
 
-Indicates a failure with the `_spender` to be approved.
+Indicates a failure with the `spender` to be approved.
 
 ##### Parameters
 
-- `address _spender` The address of who's getting owner's approval.
+- `address spender` The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -113,18 +113,18 @@ Throw when the cause of failure is the spender to be approved.
 
 #### `ERC20InsufficientAllowance(address, uint256, uint256)`
 
-Indicates a failure with the `_spender`'s `_allowance` in a transfer.
+Indicates a failure with the `spender`'s `allowance` in a transfer.
 
 ##### Parameters
 
-- `address _spender`: The address of who's spending the tokens.
-- `uint256 _allowance`: The current amount of tokens a spender can use.
-- `uint256 _needed`: The allowance needed to perform the operation.
+- `address spender`: The address of who's spending the tokens.
+- `uint256 allowance`: The current amount of tokens a spender can use.
+- `uint256 needed`: The allowance needed to perform the operation.
 
 Throw when the cause of failure is the spender's allowance.
 
-- MUST NOT be thrown if `_allowance` is equal or greater than `_needed`.
-- MUST be thrown when `_allowance` is less than `_needed`.
+- MUST NOT be thrown if `allowance` is equal or greater than `needed`.
+- MUST be thrown when `allowance` is less than `needed`.
 
 ### [EIP-721](./eip-721.md)
 
@@ -134,7 +134,7 @@ Indicates a failure with the token sender.
 
 ##### Parameters
 
-- `address _sender`: The address of whose token is transferred from.
+- `address sender`: The address of whose token is transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -149,7 +149,7 @@ Indicates a failure with the token receiver.
 
 ##### Parameters
 
-- `address _receiver`: The address of whose token is transferred to.
+- `address receiver`: The address of whose token is transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -161,23 +161,23 @@ Throw when the cause of failure is the receiver in a transfer.
 
 Indicates an error related to the ownership over a particular token.
 
-- `address _sender`: The address of whose token is transferred from.
-- `uint256 _tokenId`: The id of the token to be transferred.
+- `address sender`: The address of whose token is transferred from.
+- `uint256 tokenId`: The id of the token to be transferred.
 
 ##### Parameters
 
 Throw when the cause of failure is the ownership of a token.
 
 - MUST NOT be thrown for approval operations.
-- MUST be thrown when `ownerOf(_tokenId)` is not `_sender`.
+- MUST be thrown when `ownerOf(tokenId)` is not `sender`.
 
 #### `ERC721InvalidApprover(address)`
 
-Indicates a failure with the `_owner` of a token to be approved.
+Indicates a failure with the `owner` of a token to be approved.
 
 ##### Parameters
 
-- `address _approver`: The owner's of the token to be approved.
+- `address approver`: The owner's of the token to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
@@ -186,11 +186,11 @@ Throw when the cause of failure is the owner of the tokens to be approved.
 
 #### `ERC721InvalidOperator(address)`
 
-Indicates a failure with the `_operator` to be approved.
+Indicates a failure with the `operator` to be approved.
 
 ##### Parameters
 
-- `address _operator`: The address of who's getting owner's approval.
+- `address operator`: The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -201,17 +201,17 @@ Throw when the cause of failure is the spender to be approved.
 
 #### `ERC721InsufficientApproval(address, uint256)`
 
-Indicates a failure with the `_operator`'s approval in a transfer.
+Indicates a failure with the `operator`'s approval in a transfer.
 
 ##### Parameters
 
-- `address _operator`: The address of who's transferring a token.
-- `uint256 _tokenId`: The token to be transferred.
+- `address operator`: The address of who's transferring a token.
+- `uint256 tokenId`: The token to be transferred.
 
 Throw when the cause of failure is the operator's approval.
 
-- MUST be thrown when operator `isApprovedForAll(_owner, _operator)` is false.
-- MUST be thrown when operator `getApproved(_tokenId)` is not `_operator`.
+- MUST be thrown when operator `isApprovedForAll(owner, operator)` is false.
+- MUST be thrown when operator `getApproved(tokenId)` is not `operator`.
 
 ### [EIP-1155](./eip-1155.md)
 
@@ -221,7 +221,7 @@ Indicates a failure with the token sender.
 
 ##### Parameters
 
-- `address _sender`: The address of whose tokens are transferred from.
+- `address sender`: The address of whose tokens are transferred from.
 
 Throw when the cause of failure is the sender in a transfer.
 
@@ -236,7 +236,7 @@ Indicates a failure with the token receiver.
 
 ##### Parameters
 
-- `address _receiver` The address of whose tokens are transferred to.
+- `address receiver` The address of whose tokens are transferred to.
 
 Throw when the cause of failure is the receiver in a transfer.
 
@@ -246,27 +246,27 @@ Throw when the cause of failure is the receiver in a transfer.
 
 #### `ERC1155InsufficientBalance(address, uint256, uint256, uint256)`
 
-Indicates an error related to the current `_balance` of a sender in a transfer.
+Indicates an error related to the current `balance` of a sender in a transfer.
 
 ##### Parameters
 
-- `address _sender`: The address of whose tokens are transferred from.
-- `uint256 _balance`: The current amount of token the sender has.
-- `uint256 _needed`: The amount of token the sender needs to perform the operation.
-- `uint256 _id`: The id of the token.
+- `address sender`: The address of whose tokens are transferred from.
+- `uint256 balance`: The current amount of token the sender has.
+- `uint256 needed`: The amount of token the sender needs to perform the operation.
+- `uint256 id`: The id of the token.
 
 Throw when the cause of failure is the balance of a sender.
 
-- MUST NOT be thrown if `_balance` is equal or greater than `_needed` for an `_id`.
-- MUST be thrown when `_balance` is less than `_needed` for an `id`.
+- MUST NOT be thrown if `balance` is equal or greater than `needed` for an `id`.
+- MUST be thrown when `balance` is less than `needed` for an `id`.
 
 #### `ERC1155InvalidApprover(address)`
 
-Indicates a failure with the `_approver` of a token to be approved.
+Indicates a failure with the `approver` of a token to be approved.
 
 ##### Parameters
 
-- `address _approver`: The owner's of the tokens to be approved.
+- `address approver`: The owner's of the tokens to be approved.
 
 Throw when the cause of failure is the owner of the tokens to be approved.
 
@@ -275,11 +275,11 @@ Throw when the cause of failure is the owner of the tokens to be approved.
 
 #### `ERC1155InvalidOperator(address)`
 
-Indicates a failure with the `_operator` to be approved.
+Indicates a failure with the `operator` to be approved.
 
 ##### Parameters
 
-- `address _operator`: The address of who's getting owner's approval.
+- `address operator`: The address of who's getting owner's approval.
 
 Throw when the cause of failure is the spender to be approved.
 
@@ -290,16 +290,16 @@ Throw when the cause of failure is the spender to be approved.
 
 #### `ERC1155InsufficientApproval(address, uint256)`
 
-Indicates a failure with the `_operator`'s approval in a transfer.
+Indicates a failure with the `operator`'s approval in a transfer.
 
 ##### Parameters
 
-- `address _operator`: The address of who's transferring a token.
-- `uint256 _id`: The token to be transferred.
+- `address operator`: The address of who's transferring a token.
+- `uint256 id`: The token to be transferred.
 
 Throw when the cause of failure is the operator's approval.
 
-- MUST be thrown when operator `isApprovedForAll(_owner, _operator, _id)` is false.
+- MUST be thrown when operator `isApprovedForAll(owner, operator, id)` is false.
 
 ### Error additions
 
@@ -350,8 +350,8 @@ Although these errors are considered to be expressive enough, each error's argum
 An example of this is:
 
 ```solidity
-InsufficientApproval(address _spender, uint256 _allowance, uint256 _needed);
-InsufficientApproval(address _operator, uint256 _tokenId);
+InsufficientApproval(address spender, uint256 allowance, uint256 needed);
+InsufficientApproval(address operator, uint256 tokenId);
 ```
 
 For that reason, a domain prefix is proposed to avoid declaration clashing, which is the name of the ERC and its corresponding number appended at the beginning.
@@ -359,8 +359,8 @@ For that reason, a domain prefix is proposed to avoid declaration clashing, whic
 Example:
 
 ```solidity
-ERC20InsufficientApproval(address _spender, uint256 _allowance, uint256 _needed);
-ERC721InsufficientApproval(address _operator, uint256 _tokenId);
+ERC20InsufficientApproval(address spender, uint256 allowance, uint256 needed);
+ERC721InsufficientApproval(address operator, uint256 tokenId);
 ```
 
 ### Arguments
@@ -368,12 +368,12 @@ ERC721InsufficientApproval(address _operator, uint256 _tokenId);
 The selection of arguments depends on the subject involved, and it MUST follow the order presented below:
 
 1. _Who_ is involved with the error (an `address`) - _REQUIRED_
-2. _What_ failed (eg. `uint256 _allowance`) - _OPTIONAL_
-3. _Why_ it failed, expressed in additional arguments (eg. `uint256 _needed`) - _OPTIONAL_
+2. _What_ failed (eg. `uint256 allowance`) - _OPTIONAL_
+3. _Why_ it failed, expressed in additional arguments (eg. `uint256 needed`) - _OPTIONAL_
 
 Consider that sometimes _Who_ is also the _What_, that's why argument 2 is also optional.
 
-Note: Some tokens may need a `_tokenId` or `_id`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
+Note: Some tokens may need a `tokenId` or `id`. This is suggested to include at the end as additional information, according to the [subjects notes](#actions-and-subjects)
 
 ### Error grammar rules
 
@@ -387,7 +387,7 @@ Where:
 
 - _Domain_: SHOULD be `ERC20`, `ERC721` or `ERC1155`. Although other token standards may be suggested if not considered in this EIP.
 - _ErrorPrefix_: MAY be `Invalid`, `Insufficient`, or another if it's more appropiated.
-- _Actor_: MAY be `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropiated, and MUST make adjustments based on domain's naming convention.
+- _Subject_: MAY be `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropiated, and MUST make adjustments based on domain's naming convention.
 - _Arguments_: MUST follow the [_who_, _what_ and _why_ order](#arguments).
 
 ## Backwards Compatibility
@@ -421,17 +421,17 @@ pragma solidity ^0.8.4;
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC20Errors {
     /// @notice See [reference](#erc20invalidsender).
-    error ERC20InvalidSender(address _sender);
+    error ERC20InvalidSender(address sender);
     /// @notice See [reference](#erc20invalidreceiver).
-    error ERC20InvalidReceiver(address _receiver);
+    error ERC20InvalidReceiver(address receiver);
     /// @notice See [reference](#erc20insufficientbalance).
-    error ERC20InsufficientBalance(address _sender, uint256 _balance, uint256 _needed);
+    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
     /// @notice See [reference](#erc20invalidapprover).
-    error ERC20InvalidApprover(address _approver);
+    error ERC20InvalidApprover(address approver);
     /// @notice See [reference](#erc20invalidspender).
-    error ERC20InvalidSpender(address _spender);
+    error ERC20InvalidSpender(address spender);
     /// @notice See [reference](#erc20insufficientallowance).
-    error ERC20InsufficientAllowance(address _spender, uint256 _allowance, uint256 _needed);
+    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
 }
 
 /// @title Standard ERC721 Errors
@@ -439,17 +439,17 @@ interface ERC20Errors {
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC721Errors {
     /// @notice See [reference](#erc721invalidsender).
-    error ERC721InvalidSender(address _sender);
+    error ERC721InvalidSender(address sender);
     /// @notice See [reference](#erc721invalidreceiver).
-    error ERC721InvalidReceiver(address _receiver);
+    error ERC721InvalidReceiver(address receiver);
     /// @notice See [reference](#erc721invalidowner).
-    error ERC721InvalidOwner(address _sender, uint256 _tokenId);
+    error ERC721InvalidOwner(address sender, uint256 tokenId);
     /// @notice See [reference](#erc721invalidapprover).
-    error ERC721InvalidApprover(address _approver);
+    error ERC721InvalidApprover(address approver);
     /// @notice See [reference](#erc721invalidoperator).
-    error ERC721InvalidOperator(address _operator);
+    error ERC721InvalidOperator(address operator);
     /// @notice See [reference](#erc721insufficientapproval).
-    error ERC721InsufficientApproval(address _operator, uint256 _tokenId);
+    error ERC721InsufficientApproval(address operator, uint256 tokenId);
 }
 
 /// @title Standard ERC1155 Errors
@@ -457,17 +457,17 @@ interface ERC721Errors {
 ///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
 interface ERC1155Errors {
     /// @notice See [reference](#erc1155invalidsender).
-    error ERC1155InvalidSender(address _sender);
+    error ERC1155InvalidSender(address sender);
     /// @notice See [reference](#erc1155invalidreceiver).
-    error ERC1155InvalidReceiver(address _receiver);
+    error ERC1155InvalidReceiver(address receiver);
     /// @notice See [reference](#erc1155insufficientbalance).
-    error ERC1155InsufficientBalance(address _sender, uint256 _balance, uint256 _needed, uint256 _id);
+    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 id);
     /// @notice See [reference](#erc1155invalidapprover).
-    error ERC1155InvalidApprover(address _approver);
+    error ERC1155InvalidApprover(address approver);
     /// @notice See [reference](#erc1155invalidoperator).
-    error ERC1155InvalidOperator(address _operator);
+    error ERC1155InvalidOperator(address operator);
     /// @notice See [reference](#erc1155insufficientapproval).
-    error ERC1155InsufficientApproval(address _operator, uint256 _id);
+    error ERC1155InsufficientApproval(address operator, uint256 id);
 }
 ```
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -13,19 +13,17 @@ created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 
 ## Abstract
 
-The following specification allows for the use of a standard list of Solidity custom errors to be used within [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens.
+The following specification allows for the use of a standard list of Solidity custom errors to be used by [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens.
 
-Ethereum applications (DApps) and wallets have historically used revert statements to show relevant failure data to the users, however, this EIP provides a standard list of errors designed to give at least the same relevant information, but in a structured and expected way.
+Ethereum applications (DApps) and wallets have historically relied on revert reason strings to show the cause of transaction errors to users. More recent Solidity versions offer rich revert reasons that require error-specific decoding. This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
 
 ## Motivation
 
 Since the introduction of Solidity custom errors in v0.8.4, these have provided a way to show failures in a more expresive way with dynamic arguments, while reducing deployment costs.
 
-At the moment of the release of custom errors, the standard tokens ([EIP-20](./eip-20.md), [EIP-721](./eip-721.md), [EIP-1155](./eip-1155.md)) were already in finalized state, so no error specification was included.
+At the moment of the release of custom errors, the standard tokens ([EIP-20](./eip-20.md), [EIP-721](./eip-721.md), [EIP-1155](./eip-1155.md)) were already in finalized state, so no errors are included in their specification.
 
 An error specification will allow users to expect more consistent error messages across applications or testing environments, while exposing pertinent arguments and overall reducing the need of writing expensive revert strings in the deployment bytecode.
-
-The list of token standard errors is defined in the specification below.
 
 ## Specification
 

--- a/EIPS/eip-custom_errors_for_erc_tokens.md
+++ b/EIPS/eip-custom_errors_for_erc_tokens.md
@@ -29,7 +29,7 @@ An error specification will allow users to expect more consistent error messages
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-The provided interfaces with errors SHOULD conform with the [error grammar rules](#error-grammar-rules) described in the [rationale](#rationale) section.
+The following errors were designed according to the criteria described in [Rationale](#rationale).
 
 This EIP defines standard errors that may be used by implementations in certain scenarios, but does not specify whether implementations should revert in those scenarios, which remains up to the implementers, unless a revert is mandated by the corresponding EIPs.
 

--- a/EIPS/eip-standard_token_errors.md
+++ b/EIPS/eip-standard_token_errors.md
@@ -1,0 +1,367 @@
+---
+eip: [assignedEIPNumber]
+title: Standard Token Errors
+description: List of Solidity custom errors covering standard token implementations (EIP-20, EIP-721 and EIP-1155)
+author: Francisco Giordano (@frangio), Ernesto García (@ernestognw)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: ERC
+requires: 20, 721, 1155
+created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+---
+
+## Abstract
+
+The following specification allows for the use of a standard list of Solidity [custom errors](https://blog.soliditylang.org/2021/04/21/custom-errors/) to be used within EIP-20, EIP-721 and EIP-1155 tokens.
+
+Ethereum applications (DApps) and wallets have historically used [revert statements](https://docs.soliditylang.org/en/v0.8.16/control-structures.html#revert-statement) to show relevant failure data to the users, however, this EIP provides a standard list of errors designed to give at least the same relevant information, but in a structured and expected way.
+
+## Motivation
+
+Since the introduction of Solidity custom errors in [v0.8.4](https://github.com/ethereum/solidity/releases/tag/v0.8.4), these have provided a way to show failures in a more expresive way with dynamic arguments, while reducing deployment costs.
+
+At the moment of the release of custom errors, the standard tokens (EIP-20, EIP-721, EIP-1155) were already in finalized state, so no error specification was included.
+
+An error specification will allow users to expect more consistent error messages across applications or testing environments, while exposing pertinent arguments and overall reducing the need of writing expensive revert strings in the deployment bytecode.
+
+The list of token standard errors is defined in the specification below.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+The provided interfaces with errors SHOULD conform with the [error grammar rules](#error-grammar-rules) described in the [rationale](#rationale) section.
+
+It's important to note that errors MAY be thrown in each scenario, but that's up to the implementers, unless a revert reason is specified in their corresponding EIPs.
+
+This EIP aims to provide a clear standard only in case an error will be thrown.
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @title Standard ERC20 Errors
+/// @dev See https://eips.ethereum.org/EIPS/eip-20
+///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
+interface ERC20Errors {
+    /// @notice Indicates a failure with the token sender.
+    /// @param _sender The address of whose tokens are transferred from.
+    /// @dev Throw when the cause of failure is the sender in a transfer.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST NOT be thrown for balance or allowance requirements.
+    ///     Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
+    ///  MUST be thrown for unintended transfers from the zero address.
+    error ERC20InvalidSender(address _sender);
+
+    /// @notice Indicates a failure with the token receiver.
+    /// @param _receiver The address of whose tokens are transferred to.
+    /// @dev Throw when the cause of failure is the receiver in a transfer.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST be thrown for unintended transfers to the zero address.
+    ///  MUST be thrown for unintended transfers to non-compatible addresses (eg. contract addresses).
+    error ERC20InvalidReceiver(address _receiver);
+
+    /// @notice Indicates an error related to the current `_balance` of a sender in a transfer.
+    /// @param _sender The address of whose tokens are transferred from.
+    /// @param _balance The current amount of token the sender has.
+    /// @param _needed The amount of token the sender needs to perform the operation.
+    /// @dev Throw when the cause of failure is the balance of a sender.
+    ///  MUST NOT be thrown if `_balance` is equal or greater than `_needed`.
+    ///  MUST be thrown when `_balance` is less than `_needed`.
+    error ERC20InsufficientBalance(
+        address _sender,
+        uint256 _balance,
+        uint256 _needed
+    );
+
+    /// @notice Indicates a failure with the `_approver` of a token to be approved.
+    /// @param _approver The owner's of the tokens to be approved.
+    /// @dev Throw when the cause of failure is the owner of the tokens to be approved.
+    ///  MUST NOT be thrown for transfer operations.
+    ///  MUST be thrown for unintended approvals from the zero address.
+    error ERC20InvalidApprover(address _approver);
+
+    /// @notice Indicates a failure with the `_spender` to be approved.
+    /// @param _spender The address of who's getting owner's approval.
+    /// @dev Throw when the cause of failure is the spender to be approved.
+    ///  MUST NOT be thrown for transfer operations.
+    ///     Use `ERC20InsufficientAllowance` instead.
+    ///  MUST be thrown for unintended approvals to the zero address.
+    ///  MUST be thrown for unintended approvals to the owner itself.
+    error ERC20InvalidSpender(address _spender);
+
+    /// @notice Indicates a failure with the `_spender`'s `_allowance` in a transfer.
+    /// @param _spender The address of who's spending the tokens.
+    /// @param _allowance The current amount of tokens a spender can use.
+    /// @param _needed The allowance needed to perform the operation.
+    /// @dev Throw when the cause of failure is the spender's allowance.
+    ///  MUST NOT be thrown if `_allowance` is equal or greater than `_needed`.
+    ///  MUST be thrown when `_allowance` is less than `_needed`.
+    error ERC20InsufficientAllowance(
+        address _spender,
+        uint256 _allowance,
+        uint256 _needed
+    );
+}
+
+/// @title Standard ERC721 Errors
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
+interface ERC721Errors {
+    /// @notice Indicates a failure with the token sender.
+    /// @param _sender The address of whose token is transferred from.
+    /// @dev Throw when the cause of failure is the sender in a transfer.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST NOT be thrown for ownership or approval requirements.
+    ///     Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
+    ///  MUST be thrown for unintended transfers from the zero address.
+    error ERC721InvalidSender(address _sender);
+
+    /// @notice Indicates a failure with the token receiver.
+    /// @param _receiver The address of whose token is transferred to.
+    /// @dev Throw when the cause of failure is the receiver in a transfer.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST be thrown for unintended transfers to the zero address.
+    ///  MUST be thrown for unintended transfers to non-ERC721TokenReceiver contracts
+    ///     or those that reject a transfer.
+    ///     (eg. returning an invalid response in `onERC721Received`)
+    error ERC721InvalidReceiver(address _receiver);
+
+    /// @notice Indicates an error related to the ownership over a particular token.
+    /// @param _sender The address of whose token is transferred from.
+    /// @param _tokenId The id of the token to be transferred.
+    /// @dev Throw when the cause of failure is the ownership of a token.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST be thrown when `ownerOf(_tokenId)` is not `_sender`.
+    error ERC721InvalidOwner(address _sender, uint256 _tokenId);
+
+    /// @notice Indicates a failure with the `_owner` of a token to be approved.
+    /// @param _approver The owner's of the token to be approved.
+    /// @dev Throw when the cause of failure is the owner of the tokens to be approved.
+    ///  MUST NOT be thrown for transfer operations.
+    ///  MUST be thrown for unintended approvals from the zero address.
+    error ERC721InvalidApprover(address _approver);
+
+    /// @notice Indicates a failure with the `_operator` to be approved.
+    /// @param _operator The address of who's getting owner's approval.
+    /// @dev Throw when the cause of failure is the spender to be approved.
+    ///  MUST NOT be thrown for transfer operations.
+    ///     Use `ERC721InsufficientApproval` instead.
+    ///  MUST be thrown for unintended approvals to the zero address.
+    ///  MUST be thrown for unintended approvals to the owner itself.
+    error ERC721InvalidOperator(address _operator);
+
+    /// @notice Indicates a failure with the `_operator`'s approval in a transfer.
+    /// @param _operator The address of who's transferring a token.
+    /// @param _tokenId The token to be transferred.
+    /// @dev Throw when the cause of failure is the operator's approval.
+    ///  MUST be thrown when operator `isApprovedForAll(_owner, _operator)` is false
+    ///  MUST be thrown when operator `getApproved(_tokenId)` is not `_operator`
+    error ERC721InsufficientApproval(address _operator, uint256 _tokenId);
+}
+
+/// @title Standard ERC1155 Errors
+/// @dev See https://eips.ethereum.org/EIPS/eip-1155
+///  https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber]
+interface ERC1155Errors {
+    /// @notice Indicates a failure with the token sender.
+    /// @param _sender The address of whose tokens are transferred from.
+    /// @dev Throw when the cause of failure is the sender in a transfer.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST NOT be thrown for balance or allowance requirements.
+    ///     Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
+    ///  MUST be thrown for unintended transfers from the zero address.
+    error ERC1155InvalidSender(address _sender);
+
+    /// @notice Indicates a failure with the token receiver.
+    /// @param _receiver The address of whose tokens are transferred to.
+    /// @dev Throw when the cause of failure is the receiver in a transfer.
+    ///  MUST NOT be thrown for approval operations.
+    ///  MUST be thrown for unintended transfers to the zero address.
+    ///  MUST be thrown for unintended transfers to non-ERC1155TokenReceiver contracts
+    ///     or those that reject a transfer.
+    ///     (eg. returning an invalid response in `onERC1155Received`)
+    error ERC1155InvalidReceiver(address _receiver);
+
+    /// @notice Indicates an error related to the current `_balance` of a sender in a transfer.
+    /// @param _sender The address of whose tokens are transferred from.
+    /// @param _balance The current amount of token the sender has.
+    /// @param _needed The amount of token the sender needs to perform the operation.
+    /// @param _id The id of the token.
+    /// @dev Throw when the cause of failure is the balance of a sender.
+    ///  MUST NOT be thrown if `_balance` is equal or greater than `_needed` for an `_id`.
+    ///  MUST be thrown when `_balance` is less than `_needed` for an `id`.
+    error ERC1155InsufficientBalance(
+        address _sender,
+        uint256 _balance,
+        uint256 _needed,
+        uint256 _id
+    );
+
+    /// @notice Indicates a failure with the `_approver` of a token to be approved.
+    /// @param _approver The owner's of the tokens to be approved.
+    /// @dev Throw when the cause of failure is the owner of the tokens to be approved.
+    ///  MUST NOT be thrown for transfer operations.
+    ///  MUST be thrown for unintended approvals from the zero address.
+    error ERC1155InvalidApprover(address _approver);
+
+    /// @notice Indicates a failure with the `_operator` to be approved.
+    /// @param _operator The address of who's getting owner's approval.
+    /// @dev Throw when the cause of failure is the spender to be approved.
+    ///  MUST NOT be thrown for transfer operations.
+    ///     Use `ERC1155InsufficientApproval` instead.
+    ///  MUST be thrown for unintended approvals to the zero address.
+    ///  MUST be thrown for unintended approvals to the owner itself.
+    error ERC1155InvalidOperator(address _operator);
+
+    /// @notice Indicates a failure with the `_operator`'s approval in a transfer.
+    /// @param _operator The address of who's transferring a token.
+    /// @param _id The token to be transferred.
+    /// @dev Throw when the cause of failure is the operator's approval.
+    ///  MUST be thrown when operator `isApprovedForAll(_owner, _operator, _id)` is false
+    error ERC1155InsufficientApproval(address _operator, uint256 _id);
+}
+```
+
+## Rationale
+
+The objectives of creating a standard for token errors are to provide context about the error, while keeping gramatical sense, and making a moderated use of meaningful arguments.
+
+Considering the outlined above, the errors are designed based on the standard actions that can be performed on each token, and the [subjects](#actions-and-subjects) involved.
+
+### Actions and subjects
+
+The main actions that can be performed within a token are:
+
+- **Transfer**: An operation in which a _sender_ moves any form of _balance_ to a _receiver_.
+- **Approval**: An operation in which an _approver_ grants any form of _approval_ to an _operator_
+
+Giving the following list of subjects:
+
+- **Sender**
+- **Receiver**
+- **Balance**
+- **Approver**
+- **Operator**
+- **Approval**
+
+These subjects are expected to be exhaustive to represent _what_ can go wrong on a transaction, which can be shown as an error by adding a [failure prefix](#error-prefixes).
+
+Note that `Token` or `TokenID` MUST NOT be a subject for the following reasons:
+
+1. The [Domain](#domain) is explicit enough to identify it as a token error.
+2. Although `TokenID` may identify an error, the token itself SHOULD NOT the root of the error, but can be additional information.
+
+### Error prefixes
+
+- **Invalid**: Used for general incorrectness.
+- **Insufficient**: Used when defining an error for amounts (eg. balance, approval).
+
+These prefixes combined with the subjects create the following list of base standard errors.
+
+### Base standard errors
+
+- **InvalidSender**
+- **InvalidReceiver**
+- **InsufficientBalance**
+- **InvalidApprover**
+- **InvalidOperator**
+- **InsufficientApproval**
+
+### Domain
+
+Although these errors are considered to be expressive enough, each error's arguments may vary depending on the token domain, causing a `DeclarationError` if there are errors with the same name and different arguments.
+
+An example of this is:
+
+```solidity
+InsufficientApproval(address _spender, uint256 _allowance, uint256 _needed);
+InsufficientApproval(address _operator, uint256 _tokenId);
+```
+
+For that reason, a domain prefix is proposed to avoid declaration clashing, which is the name of the ERC and its corresponding number appended at the beginning.
+
+Example:
+
+```solidity
+ERC20InsufficientApproval(address _spender, uint256 _allowance, uint256 _needed);
+ERC721InsufficientApproval(address _operator, uint256 _tokenId);
+```
+
+### Subject naming adjustments
+
+While the base standard errors can work with the current standard token implementations, in practice, some of the subjects in a contract might be called different while they represent the same. These are listed below:
+
+- **Balance**: Represents the access to a certain amount of tokens for an address.
+  - EIP-721: Instead of _balance_, an address is _owner_ of a token.
+- **Approval**: Represents a permission granted to an operator.
+  - EIP-20: Instead of _approval_, an operator has _allowance_.
+- **Operator**: Represents an address that has received approval over third-party tokens.
+  - EIP-20: Instead of _operator_, an address with allowance is an _spender_.
+
+If a subject is called different on a particular token standard, the error MUST be consistent with the standard's naming convention.
+
+### Arguments
+
+The selection of arguments depends on the subject involved, and it MUST follow the order presented below:
+
+1. _Who_ is involved with the error (an `address`) - _REQUIRED_
+2. _What_ failed (eg. `uint256 _allowance`) - _OPTIONAL_
+3. _Why_ it failed, expressed in additional arguments (eg. `uint256 _needed`) - _OPTIONAL_
+
+Consider that sometimes _Who_ is also the _What_, that's why argument 2 is also optional.
+
+Note: Some tokens may need a `_tokenId` or `_id`. This is suggested to include at the end as additional information, according to the [subjects list](#actions-and-subjects)
+
+### Error grammar rules
+
+Given the above, we can summarize the construction of error names with a grammar that errors MUST follow:
+
+```
+<Domain><ErrorPrefix><Subject>(<Arguments>);
+```
+
+Where:
+
+- _Domain_: SHOULD be `ERC20`, `ERC721` or `ERC1155`. Although other token standards may be suggested if not considered in this EIP.
+- _ErrorPrefix_: MUST be `Invalid` or `Insufficient`.
+- _Actor_: SHOULD be `Sender`, `Receiver`, `Balance`, `Approver`, `Operator` or `Approval`, and MUST make adjustments based on domain's naming convention.
+- _Arguments_: MUST follow the [_who_, _what_ and _why_ order](#arguments).
+
+## Backwards Compatibility
+
+<!-- All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright. -->
+
+This EIP can not be enforced on non-upgradeable already deployed tokens, however, these tokens generally use similar conventions with small variations such as:
+
+- including/removing the [domain](#domain).
+- using different [error prefixes](#error-prefixes).
+- including similar [subjects](#actions-and-subjects).
+- changing the grammar order.
+
+New deployed contracts MUST use this EIP whenever possible. Errors in extensions are not considered in this EIP and MAY have different subjects.
+
+Upgradeable contracts MAY be upgraded to implement this EIP.
+
+Implementers and DApp developers SHOULD expect these EIP errors to be present on new deployed contracts, but MUST handle variation errors for existing contracts, and revert strings that may be returned.
+
+## Reference Implementation
+
+<!-- An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification. If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/eip-####/`. -->
+
+## Security Considerations
+
+There are no known signature hash collision for the specified errors.
+
+Tokens upgraded to implement this EIP may break assumptions in other systems relying on revert strings.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).
+
+## Citation
+
+Please cite this document as:
+
+Francisco Giordano, Ernesto García, "EIP-[assignedEIPNumber]: Standard Token Errors [DRAFT]," Ethereum Improvement Proposals, no. [assignedEIPNumber], November 2022. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-[assignedEIPNumber].


### PR DESCRIPTION
## Description

Created EIP-draft for the errors to be thrown in the standard token implementations (ERC20, ERC721, ERC1155).